### PR TITLE
feat: add dashboard-page-setup spec (requirements, design, tasks)

### DIFF
--- a/.kiro/specs/dashboard-page-setup/.config.kiro
+++ b/.kiro/specs/dashboard-page-setup/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "02e20267-24cb-443b-a66f-b2d2d8a25612", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/dashboard-page-setup/design.md
+++ b/.kiro/specs/dashboard-page-setup/design.md
@@ -1,0 +1,396 @@
+# Design Document: Dashboard Page Setup
+
+## Overview
+
+This feature replaces the placeholder `src/app/page.tsx` with the real Stellar-Spend off-ramp dashboard and updates `src/app/layout.tsx` with accurate metadata including Open Graph tags.
+
+The work involves two distinct changes:
+
+1. **New component** — `StellarSpendDashboard` (`src/components/StellarSpendDashboard.tsx`): a `"use client"` component that owns wallet state via `useStellarWallet` and wires it to `Header`, `FormCard`, and `RightPanel`.
+2. **Page wiring** — `src/app/page.tsx` becomes a thin server component that renders `<StellarSpendDashboard />` as its sole child.
+3. **Metadata update** — `src/app/layout.tsx` gains a complete `Metadata` export with title, description, and Open Graph fields.
+
+---
+
+## Architecture
+
+The dashboard follows Next.js App Router conventions: the root page is a server component that delegates all interactivity to a single client component boundary.
+
+```mermaid
+graph TD
+    A["page.tsx (Server Component)"] --> B["StellarSpendDashboard (Client Component)"]
+    B --> C["useStellarWallet (hook)"]
+    B --> D["Header"]
+    B --> E["FormCard"]
+    B --> F["RightPanel"]
+    C --> G["StellarWalletAdapter"]
+    E -- "onQuoteChange / onAmountChange / onCurrencyChange" --> B
+    B -- "quote / amount / currency" --> F
+```
+
+State flows in one direction: `useStellarWallet` provides wallet state upward to `StellarSpendDashboard`, which distributes it downward as props to the three sub-components. `FormCard` lifts quote/amount/currency changes back up via callbacks so `RightPanel` stays in sync.
+
+---
+
+## Components and Interfaces
+
+### `StellarSpendDashboard`
+
+**File:** `src/components/StellarSpendDashboard.tsx`
+
+```ts
+// No external props — self-contained
+export default function StellarSpendDashboard(): JSX.Element
+```
+
+Internal state managed by this component:
+
+| State variable | Type | Purpose |
+|---|---|---|
+| `quote` | `QuoteResult \| null` | Latest quote from FormCard, forwarded to RightPanel |
+| `amount` | `string` | Current USDC amount, forwarded to RightPanel |
+| `currency` | `string` | Selected payout currency, forwarded to RightPanel |
+| `resetKey` | `number` | Incremented after successful submit to reset FormCard |
+
+Wallet state is sourced entirely from `useStellarWallet`:
+
+| Value | Type | Usage |
+|---|---|---|
+| `isConnected` | `boolean` | Passed to Header, FormCard, RightPanel |
+| `isConnecting` | `boolean` | Passed to Header, FormCard, RightPanel |
+| `wallet.publicKey` | `string \| undefined` | Passed as `walletAddress` to Header |
+| `connect` | `() => Promise<StellarWallet>` | Passed as `onConnect` to Header, FormCard, RightPanel |
+| `disconnect` | `() => void` | Passed as `onDisconnect` to Header |
+
+**Props passed to `Header`:**
+
+```ts
+{
+  subtitle: "STABLECOIN OFF-RAMP",
+  isConnected,
+  isConnecting,
+  walletAddress: wallet?.publicKey,
+  onConnect: connect,
+  onDisconnect: disconnect,
+}
+```
+
+Note: `stellarUsdcBalance`, `stellarXlmBalance`, and `isBalanceLoading` are optional on `HeaderProps` and will be omitted in the initial implementation (balance fetching is out of scope for this feature).
+
+**Props passed to `FormCard`:**
+
+```ts
+{
+  isConnected,
+  isConnecting,
+  resetKey,
+  onConnect: connect,
+  onSubmit: handleSubmit,
+  onQuoteChange: setQuote,
+  onAmountChange: setAmount,
+  onCurrencyChange: setCurrency,
+}
+```
+
+**Props passed to `RightPanel`:**
+
+```ts
+{
+  isConnected,
+  isConnecting,
+  quote,
+  amount,
+  currency,
+  isLoadingQuote: false,   // RightPanel manages its own loading display via quote === null
+  onConnect: connect,
+}
+```
+
+**`handleSubmit` implementation:**
+
+The `onSubmit` callback received from `FormCard` triggers the full offramp flow. For this feature scope, `handleSubmit` will log the payload and increment `resetKey` on success. The actual transaction execution (bridge + payout) is handled by existing API routes and is outside this feature's scope.
+
+```ts
+async function handleSubmit(payload: OfframpPayload): Promise<void> {
+  // Placeholder: real execution wired in a future feature
+  console.log("Offramp payload:", payload);
+  setResetKey((k) => k + 1);
+}
+```
+
+---
+
+### `page.tsx` (updated)
+
+**File:** `src/app/page.tsx`
+
+Becomes a minimal server component:
+
+```tsx
+import StellarSpendDashboard from "@/components/StellarSpendDashboard";
+
+export default function Page() {
+  return <StellarSpendDashboard />;
+}
+```
+
+No layout wrapper is added here — the existing `RootLayout` in `layout.tsx` already provides the `<html>` and `<body>` tags with font variables.
+
+---
+
+### `layout.tsx` (updated)
+
+**File:** `src/app/layout.tsx`
+
+The `metadata` export is expanded:
+
+```ts
+export const metadata: Metadata = {
+  title: "Stellar-Spend — Convert Stablecoins to Fiat",
+  description:
+    "Stellar-Spend is a non-custodial off-ramp that converts Stellar USDC to local fiat currencies. Connect your Stellar wallet, enter payout details, and settle directly to your bank account.",
+  openGraph: {
+    title: "Stellar-Spend — Convert Stablecoins to Fiat",
+    description:
+      "Stellar-Spend is a non-custodial off-ramp that converts Stellar USDC to local fiat currencies. Connect your Stellar wallet, enter payout details, and settle directly to your bank account.",
+    type: "website",
+    url: process.env.NEXT_PUBLIC_APP_URL,   // optional; omitted when undefined
+  },
+};
+```
+
+The `url` field is conditionally included: Next.js silently omits `undefined` values from the rendered meta tags, so no runtime guard is needed.
+
+---
+
+## Data Models
+
+### `QuoteResult` (existing, from `FormCard.tsx`)
+
+```ts
+interface QuoteResult {
+  destinationAmount: string;
+  rate: number;
+  currency: string;
+  bridgeFee: string;
+  payoutFee: string;
+  estimatedTime: number;
+}
+```
+
+`StellarSpendDashboard` stores a `QuoteResult | null` in state and passes it directly to `RightPanel`. No transformation is needed.
+
+### `OfframpPayload` (existing, from `FormCard.tsx`)
+
+```ts
+interface OfframpPayload {
+  amount: string;
+  currency: string;
+  institution: string;
+  accountIdentifier: string;
+  accountName: string;
+  feeMethod: "USDC" | "XLM";
+  quote: QuoteResult;
+}
+```
+
+Passed from `FormCard` to `StellarSpendDashboard.handleSubmit` on form submission.
+
+### `StellarWallet` (existing, from `wallet-adapter.ts`)
+
+```ts
+interface StellarWallet {
+  type: "freighter" | "lobstr";
+  publicKey: string;
+  isConnected: boolean;
+}
+```
+
+`wallet?.publicKey` is forwarded to `Header` as `walletAddress`.
+
+### Metadata shape (Next.js `Metadata`)
+
+```ts
+{
+  title: string;
+  description: string;
+  openGraph: {
+    title: string;
+    description: string;
+    type: "website";
+    url?: string;
+  };
+}
+```
+
+---
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Dashboard renders all sub-components
+
+*For any* render of `StellarSpendDashboard`, the output must contain `Header`, `FormCard`, and `RightPanel` as descendants.
+
+**Validates: Requirements 1.1, 1.2**
+
+---
+
+### Property 2: Wallet state is forwarded to all child components
+
+*For any* combination of `isConnected`, `isConnecting`, and `walletAddress` values returned by `useStellarWallet`, `StellarSpendDashboard` must pass those exact values to `Header`, `FormCard`, and `RightPanel` as their respective props.
+
+**Validates: Requirements 2.5, 2.6, 2.7**
+
+---
+
+### Property 3: Form state changes propagate to RightPanel
+
+*For any* value emitted by `FormCard` via `onQuoteChange`, `onAmountChange`, or `onCurrencyChange`, `RightPanel` must subsequently receive that same value as its corresponding prop (`quote`, `amount`, or `currency`).
+
+**Validates: Requirements 2.8, 2.9, 2.10**
+
+---
+
+### Property 4: Open Graph metadata is consistent with page metadata
+
+*For any* `Metadata` object exported from `layout.tsx`, `openGraph.title` must equal `title` and `openGraph.description` must equal `description`.
+
+**Validates: Requirements 5.2, 5.3**
+
+---
+
+## Error Handling
+
+### Render errors in `StellarSpendDashboard`
+
+`page.tsx` does not wrap `StellarSpendDashboard` in a React `ErrorBoundary`. Any unhandled render error thrown by `StellarSpendDashboard` or its children will propagate up to the nearest Next.js error boundary (the root `error.tsx` if present, or the framework's default error page). This is intentional — the feature does not introduce new error recovery logic.
+
+### Wallet connection errors
+
+`useStellarWallet` already handles connection errors internally, setting an `error` string and re-throwing. `StellarSpendDashboard` does not need to catch these; `Header` and `FormCard` display appropriate disabled/loading states when `isConnecting` is true.
+
+### Missing `NEXT_PUBLIC_APP_URL`
+
+When the environment variable is not set, `openGraph.url` will be `undefined`. Next.js omits `undefined` metadata fields from the rendered HTML, so no `og:url` tag will appear. This is acceptable behavior — the other OG tags remain valid.
+
+### Quote and account verification errors
+
+These are handled entirely within `FormCard` (existing implementation). `StellarSpendDashboard` only receives the final resolved `QuoteResult` via `onQuoteChange`; it never sees intermediate errors.
+
+---
+
+## Testing Strategy
+
+### Dual Testing Approach
+
+Both unit tests and property-based tests are used. Unit tests cover specific examples and integration points; property-based tests verify universal properties across generated inputs.
+
+### Unit Tests
+
+Focus areas:
+
+- **`page.tsx`**: Render the page and assert `StellarSpendDashboard` is present (Requirement 1.1 / Property 1).
+- **`layout.tsx` metadata**: Import the `metadata` export and assert exact field values for title, description, `openGraph.type`, and `openGraph.title`/`openGraph.description` consistency (Requirements 3.1, 4.1, 5.1, 5.4).
+- **`StellarSpendDashboard` connect/disconnect**: Mock `useStellarWallet`, render the component, simulate button clicks, and assert `connect`/`disconnect` were called (Requirements 2.3, 2.4).
+- **Error propagation edge case**: Mock `StellarSpendDashboard` to throw during render and assert the error is not swallowed by `page.tsx` (Requirement 1.3).
+- **OG URL edge case**: Assert that when `NEXT_PUBLIC_APP_URL` is undefined, `openGraph.url` is also undefined (Requirement 5.5).
+
+### Property-Based Tests
+
+Property-based testing library: **fast-check** (already compatible with the TypeScript/Jest/Vitest ecosystem used in Next.js projects).
+
+Each property test runs a minimum of **100 iterations**.
+
+---
+
+**Property 1: Dashboard renders all sub-components**
+
+```
+// Feature: dashboard-page-setup, Property 1: Dashboard renders all sub-components
+fc.assert(
+  fc.property(
+    fc.record({ isConnected: fc.boolean(), isConnecting: fc.boolean(), publicKey: fc.option(fc.string()) }),
+    (walletState) => {
+      // Mock useStellarWallet with generated state
+      // Render StellarSpendDashboard
+      // Assert Header, FormCard, RightPanel are all present in the output
+    }
+  ),
+  { numRuns: 100 }
+);
+```
+
+---
+
+**Property 2: Wallet state is forwarded to all child components**
+
+```
+// Feature: dashboard-page-setup, Property 2: Wallet state is forwarded to all child components
+fc.assert(
+  fc.property(
+    fc.record({
+      isConnected: fc.boolean(),
+      isConnecting: fc.boolean(),
+      publicKey: fc.option(fc.string({ minLength: 56, maxLength: 56 })),
+    }),
+    (walletState) => {
+      // Mock useStellarWallet to return walletState
+      // Render StellarSpendDashboard
+      // Assert Header receives isConnected, isConnecting, walletAddress matching walletState
+      // Assert FormCard receives isConnected, isConnecting matching walletState
+      // Assert RightPanel receives isConnected, isConnecting matching walletState
+    }
+  ),
+  { numRuns: 100 }
+);
+```
+
+---
+
+**Property 3: Form state changes propagate to RightPanel**
+
+```
+// Feature: dashboard-page-setup, Property 3: Form state changes propagate to RightPanel
+fc.assert(
+  fc.property(
+    fc.record({
+      amount: fc.string(),
+      currency: fc.string({ minLength: 3, maxLength: 3 }),
+      quote: fc.option(fc.record({
+        destinationAmount: fc.string(),
+        rate: fc.float({ min: 0 }),
+        currency: fc.string(),
+        bridgeFee: fc.string(),
+        payoutFee: fc.string(),
+        estimatedTime: fc.nat(),
+      })),
+    }),
+    ({ amount, currency, quote }) => {
+      // Render StellarSpendDashboard
+      // Simulate FormCard calling onAmountChange(amount), onCurrencyChange(currency), onQuoteChange(quote)
+      // Assert RightPanel receives amount, currency, quote matching the emitted values
+    }
+  ),
+  { numRuns: 100 }
+);
+```
+
+---
+
+**Property 4: Open Graph metadata is consistent with page metadata**
+
+```
+// Feature: dashboard-page-setup, Property 4: Open Graph metadata is consistent with page metadata
+fc.assert(
+  fc.property(fc.constant(metadata), (meta) => {
+    // Assert meta.openGraph.title === meta.title
+    // Assert meta.openGraph.description === meta.description
+  }),
+  { numRuns: 100 }
+);
+```
+
+Note: Since `metadata` is a static object, this property effectively runs as a single example. The `fc.constant` wrapper keeps it consistent with the property-based test format and allows future parameterization if metadata generation is added.

--- a/.kiro/specs/dashboard-page-setup/requirements.md
+++ b/.kiro/specs/dashboard-page-setup/requirements.md
@@ -1,0 +1,81 @@
+# Requirements Document
+
+## Introduction
+
+Replace the placeholder `page.tsx` with the real Stellar-Spend dashboard by rendering the `StellarSpendDashboard` component, and update `layout.tsx` with accurate metadata including Open Graph tags for social sharing.
+
+## Glossary
+
+- **StellarSpendDashboard**: The top-level client component that composes `Header`, `FormCard`, and `RightPanel` into the full off-ramp dashboard UI.
+- **Page**: The Next.js root route (`src/app/page.tsx`) served at `/`.
+- **Layout**: The Next.js root layout (`src/app/layout.tsx`) that wraps all pages and defines document-level metadata.
+- **Metadata**: Next.js `Metadata` object exported from `layout.tsx` that controls `<title>`, `<meta description>`, and Open Graph tags.
+- **Open_Graph**: A set of `<meta property="og:*">` tags that control how the page appears when shared on social platforms.
+
+---
+
+## Requirements
+
+### Requirement 1: Dashboard Page Render
+
+**User Story:** As a user, I want to open `http://localhost:3000` and see the Stellar-Spend off-ramp dashboard, so that I can convert stablecoins to fiat without navigating to a sub-route.
+
+#### Acceptance Criteria
+
+1. THE `Page` SHALL render the `StellarSpendDashboard` component as its sole child.
+2. WHEN a browser navigates to `/`, THE `Page` SHALL display the `Header`, `FormCard`, and `RightPanel` sub-components.
+3. IF the `StellarSpendDashboard` component throws a render error, THEN THE `Page` SHALL propagate the error to the Next.js error boundary.
+
+---
+
+### Requirement 2: StellarSpendDashboard Component
+
+**User Story:** As a developer, I want a single `StellarSpendDashboard` component that wires wallet state to the form and right panel, so that the dashboard is self-contained and importable from any route.
+
+#### Acceptance Criteria
+
+1. THE `StellarSpendDashboard` SHALL be a client component (`"use client"` directive).
+2. THE `StellarSpendDashboard` SHALL use `useStellarWallet` to manage wallet connection state.
+3. WHEN the user clicks "Connect Wallet", THE `StellarSpendDashboard` SHALL invoke the wallet `connect` function.
+4. WHEN the user clicks "Disconnect", THE `StellarSpendDashboard` SHALL invoke the wallet `disconnect` function.
+5. THE `StellarSpendDashboard` SHALL pass `isConnected`, `isConnecting`, `walletAddress`, and balance props to `Header`.
+6. THE `StellarSpendDashboard` SHALL pass `isConnected`, `isConnecting`, `onConnect`, and `onSubmit` props to `FormCard`.
+7. THE `StellarSpendDashboard` SHALL pass `isConnected`, `isConnecting`, `quote`, `amount`, `currency`, and `onConnect` props to `RightPanel`.
+8. WHEN `FormCard` calls `onQuoteChange`, THE `StellarSpendDashboard` SHALL update the quote state passed to `RightPanel`.
+9. WHEN `FormCard` calls `onAmountChange`, THE `StellarSpendDashboard` SHALL update the amount state passed to `RightPanel`.
+10. WHEN `FormCard` calls `onCurrencyChange`, THE `StellarSpendDashboard` SHALL update the currency state passed to `RightPanel`.
+
+---
+
+### Requirement 3: Page Title Metadata
+
+**User Story:** As a user, I want the browser tab to display "Stellar-Spend — Convert Stablecoins to Fiat", so that I can identify the page at a glance.
+
+#### Acceptance Criteria
+
+1. THE `Layout` SHALL export a `Metadata` object with `title` set to `"Stellar-Spend — Convert Stablecoins to Fiat"`.
+2. WHEN the page is rendered, THE browser tab SHALL display the title `"Stellar-Spend — Convert Stablecoins to Fiat"`.
+
+---
+
+### Requirement 4: Page Description Metadata
+
+**User Story:** As a developer, I want an accurate meta description, so that search engines and link previews reflect the real purpose of the application.
+
+#### Acceptance Criteria
+
+1. THE `Layout` SHALL export a `Metadata` object with `description` set to an accurate summary of the Stellar-Spend off-ramp application.
+
+---
+
+### Requirement 5: Open Graph Metadata
+
+**User Story:** As a product owner, I want Open Graph tags on the page, so that sharing the URL on social platforms renders a rich preview card.
+
+#### Acceptance Criteria
+
+1. THE `Layout` SHALL include an `openGraph` field in the `Metadata` object.
+2. THE `openGraph` metadata SHALL include a `title` matching the page title.
+3. THE `openGraph` metadata SHALL include a `description` matching the page description.
+4. THE `openGraph` metadata SHALL include a `type` of `"website"`.
+5. WHERE a canonical URL is configured, THE `openGraph` metadata SHALL include a `url` field.

--- a/.kiro/specs/dashboard-page-setup/tasks.md
+++ b/.kiro/specs/dashboard-page-setup/tasks.md
@@ -1,0 +1,70 @@
+# Implementation Plan: Dashboard Page Setup
+
+## Overview
+
+Wire the existing `Header`, `FormCard`, and `RightPanel` components into a new `StellarSpendDashboard` client component, replace the placeholder `page.tsx` with a thin server component that renders it, and expand `layout.tsx` with complete Open Graph metadata.
+
+## Tasks
+
+- [ ] 1. Create `StellarSpendDashboard` component
+  - Create `src/components/StellarSpendDashboard.tsx` with `"use client"` directive
+  - Use `useStellarWallet` to source `isConnected`, `isConnecting`, `wallet`, `connect`, `disconnect`
+  - Manage local state: `quote: QuoteResult | null`, `amount: string`, `currency: string`, `resetKey: number`
+  - Render `Header`, `FormCard`, and `RightPanel` with props as specified in the design
+  - Implement `handleSubmit` that logs the payload and increments `resetKey`
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 2.10_
+
+  - [ ]* 1.1 Write property test — Dashboard renders all sub-components (Property 1)
+    - **Property 1: Dashboard renders all sub-components**
+    - Mock `useStellarWallet` with `fc.record({ isConnected: fc.boolean(), isConnecting: fc.boolean(), publicKey: fc.option(fc.string()) })`
+    - Assert `Header`, `FormCard`, and `RightPanel` are all present in the rendered output for every generated wallet state
+    - **Validates: Requirements 1.1, 1.2**
+
+  - [ ]* 1.2 Write property test — Wallet state forwarded to all child components (Property 2)
+    - **Property 2: Wallet state is forwarded to all child components**
+    - Mock `useStellarWallet` with generated `isConnected`, `isConnecting`, `publicKey` values
+    - Assert `Header`, `FormCard`, and `RightPanel` each receive the exact values returned by the hook
+    - **Validates: Requirements 2.5, 2.6, 2.7**
+
+  - [ ]* 1.3 Write property test — Form state changes propagate to RightPanel (Property 3)
+    - **Property 3: Form state changes propagate to RightPanel**
+    - Render `StellarSpendDashboard`, simulate `FormCard` calling `onAmountChange`, `onCurrencyChange`, `onQuoteChange` with generated values
+    - Assert `RightPanel` subsequently receives those exact values as `amount`, `currency`, `quote`
+    - **Validates: Requirements 2.8, 2.9, 2.10**
+
+- [ ] 2. Update `page.tsx` to render `StellarSpendDashboard`
+  - Replace the placeholder content in `src/app/page.tsx` with a minimal server component that imports and renders `<StellarSpendDashboard />`
+  - Remove all existing placeholder JSX
+  - _Requirements: 1.1, 1.2, 1.3_
+
+  - [ ]* 2.1 Write unit test — page renders StellarSpendDashboard
+    - Render `Page` and assert `StellarSpendDashboard` is present in the output
+    - Assert that a render error thrown by `StellarSpendDashboard` propagates (is not swallowed by `page.tsx`)
+    - **Validates: Requirements 1.1, 1.3**
+
+- [ ] 3. Checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 4. Update `layout.tsx` metadata with Open Graph tags
+  - Expand the `metadata` export in `src/app/layout.tsx` to include the full title, description, and `openGraph` object (`title`, `description`, `type: "website"`, `url: process.env.NEXT_PUBLIC_APP_URL`)
+  - _Requirements: 3.1, 4.1, 5.1, 5.2, 5.3, 5.4, 5.5_
+
+  - [ ]* 4.1 Write unit test — metadata fields are correct
+    - Import the `metadata` export and assert `title`, `description`, `openGraph.type` match expected values
+    - Assert `openGraph.url` is `undefined` when `NEXT_PUBLIC_APP_URL` is not set
+    - **Validates: Requirements 3.1, 4.1, 5.1, 5.4, 5.5**
+
+  - [ ]* 4.2 Write property test — Open Graph metadata is consistent with page metadata (Property 4)
+    - **Property 4: Open Graph metadata is consistent with page metadata**
+    - Use `fc.constant(metadata)` and assert `openGraph.title === title` and `openGraph.description === description`
+    - **Validates: Requirements 5.2, 5.3**
+
+- [ ] 5. Final checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- Each task references specific requirements for traceability
+- Property tests use `fast-check` with a minimum of 100 iterations per property
+- `handleSubmit` is a placeholder — actual bridge/payout execution is out of scope for this feature


### PR DESCRIPTION
Dashboard Page Setup — Spec

This spec formalizes the work needed to replace the placeholder page.tsx with the real Stellar-Spend off-ramp dashboard and update layout.tsx with production-ready metadata.

What's being built

A new StellarSpendDashboard client component (
StellarSpendDashboard.tsx
) that acts as the top-level orchestrator for the dashboard UI. It owns all wallet state via the existing useStellarWallet hook and distributes that state downward as props to the three existing sub-components — Header, FormCard, and RightPanel. It also manages local UI state for the quote result, selected amount, and payout currency, keeping RightPanel in sync as the user interacts with FormCard.

page.tsx becomes a minimal Next.js server component — a single import and a single JSX line — delegating all interactivity to the client boundary inside StellarSpendDashboard.

layout.tsx gets a complete Metadata export: the browser tab title is set to "Stellar-Spend — Convert Stablecoins to Fiat", an accurate meta description is added for search engines, and a full Open Graph block (title, description, type: "website", and an optional url from NEXT_PUBLIC_APP_URL) is included so the app renders rich preview cards when shared on social platforms.

Why it's structured this way

The server/client split follows Next.js App Router best practices — the root page stays a server component for performance, while the single "use client" boundary is pushed as deep as possible into StellarSpendDashboard. State flows in one direction: the wallet hook feeds state up to the dashboard, which fans it out as props. FormCard lifts quote/amount/currency changes back up via callbacks so RightPanel always reflects the current form state without any sibling-to-sibling coupling.

Correctness properties defined

Four formal properties were derived from the requirements to guide testing:

StellarSpendDashboard always renders Header, FormCard, and RightPanel regardless of wallet state
Whatever useStellarWallet returns for isConnected, isConnecting, and walletAddress is forwarded exactly to all three child components
Any value emitted by FormCard via onQuoteChange, onAmountChange, or onCurrencyChange is immediately reflected in RightPanel's corresponding props
openGraph.title and openGraph.description in layout.tsx always match the top-level title and description fields
Testing approach

Property-based tests using fast-check (100 iterations minimum per property) cover the four correctness properties above. Unit tests cover specific examples: page render, connect/disconnect button interactions, metadata field values, and the edge case where NEXT_PUBLIC_APP_URL is undefined.

Implementation tasks

The work is broken into 5 tasks: create StellarSpendDashboard, update page.tsx, a mid-point test checkpoint, update layout.tsx metadata, and a final test checkpoint. Optional sub-tasks attach the property-based tests to their respective implementation tasks for traceability.

Closes #47 