### PR TITLE
spec: add state-switcher requirements, design, and tasks

### DIFF
--- a/.kiro/specs/state-switcher/.config.kiro
+++ b/.kiro/specs/state-switcher/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "98ad0956-8829-416a-a8fd-3b0794eab07f", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/state-switcher/design.md
+++ b/.kiro/specs/state-switcher/design.md
@@ -1,0 +1,221 @@
+# Design Document: StateSwitcher
+
+## Overview
+
+The StateSwitcher is a development/demo-only tab-bar component that lets developers
+and reviewers manually cycle through the three `WalletFlowState` values
+(`"pre_connect"`, `"connecting"`, `"connected"`) without a real Stellar wallet.
+
+It is a **controlled, stateless component**: it owns no internal state, receives the
+current state and a change handler as props, and delegates all rendering decisions to
+those props. Visibility is gated at render time by checking `NODE_ENV` and the
+`NEXT_PUBLIC_ENABLE_STATE_SWITCHER` environment variable.
+
+The component slots into the existing dashboard layout (`src/app/page.tsx`) above or
+below the main content area and wires directly into the `useWalletFlow` hook that
+already drives the rest of the UI.
+
+---
+
+## Architecture
+
+```mermaid
+flowchart TD
+    A[page.tsx] -->|state, setState| B[useWalletFlow hook]
+    A -->|state, onStateChange| C[StateSwitcher]
+    A -->|isConnected, isConnecting| D[Header]
+    A -->|isConnected, isConnecting| E[FormCard]
+    A -->|isConnected, isConnecting| F[RightPanel]
+    C -->|onStateChange callback| A
+    B -->|variant, steps| A
+```
+
+The page holds the single source of truth (`WalletFlowState`). StateSwitcher reads
+it via the `state` prop and writes back via `onStateChange`. No new global state or
+context is introduced.
+
+---
+
+## Components and Interfaces
+
+### `StateSwitcher` (`src/components/StateSwitcher.tsx`)
+
+```ts
+export interface StateSwitcherProps {
+  /** Currently active wallet flow state — determines which tab is highlighted. */
+  state: WalletFlowState;
+  /** Called with the new state when a tab is clicked or activated via keyboard. */
+  onStateChange: (state: WalletFlowState) => void;
+}
+```
+
+**Visibility guard** (evaluated at the top of the render function):
+
+```ts
+const isDev = process.env.NODE_ENV === "development";
+const flagEnabled = process.env.NEXT_PUBLIC_ENABLE_STATE_SWITCHER === "true";
+if (!isDev && !flagEnabled) return null;
+```
+
+**Tab definitions** (static, defined outside the component):
+
+```ts
+const TABS: Array<{ label: string; value: WalletFlowState }> = [
+  { label: "Pre Connect", value: "pre_connect" },
+  { label: "Connecting",  value: "connecting"  },
+  { label: "Connected",   value: "connected"   },
+];
+```
+
+**Keyboard navigation** is handled via an `onKeyDown` handler on each `<button>`.
+`ArrowRight` / `ArrowLeft` compute the next index with wrap-around and call
+`element.focus()` on the target button via a `refs` array. `Enter` / `Space` invoke
+`onStateChange` (the browser fires `click` on `Space` for buttons natively, but we
+handle it explicitly for clarity).
+
+**ARIA roles**:
+- Container `<div>` → `role="tablist"`
+- Each `<button>` → `role="tab"`, `aria-selected={isActive}`
+
+### Integration in `page.tsx`
+
+```tsx
+const { state, setState, variant, steps } = useWalletFlow("pre_connect");
+
+// Derive boolean flags consumed by existing components
+const isConnected  = state === "connected";
+const isConnecting = state === "connecting";
+
+// ...
+
+<StateSwitcher state={state} onStateChange={setState} />
+```
+
+No changes are required to `Header`, `FormCard`, or `RightPanel` — they already
+accept `isConnected` / `isConnecting` booleans.
+
+---
+
+## Data Models
+
+No new data models are introduced. The component relies entirely on the existing
+`WalletFlowState` union type from `src/types/stellaramp.ts`:
+
+```ts
+export type WalletFlowState = "pre_connect" | "connecting" | "connected";
+```
+
+The static `TABS` array (defined inside `StateSwitcher.tsx`) is the only new
+data structure, and it is a plain constant — not persisted or shared.
+
+**Environment variables** (already declared in `.env.example` or to be added):
+
+| Variable | Type | Purpose |
+|---|---|---|
+| `NODE_ENV` | runtime | Standard Next.js env; `"development"` enables the component |
+| `NEXT_PUBLIC_ENABLE_STATE_SWITCHER` | `"true"` \| unset | Opt-in flag for non-dev environments |
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Always renders exactly three tabs
+
+*For any* valid `WalletFlowState` passed as the `state` prop, the StateSwitcher SHALL
+render exactly three `<button role="tab">` elements with labels "Pre Connect",
+"Connecting", and "Connected" in that order.
+
+**Validates: Requirements 1.1, 1.4**
+
+---
+
+### Property 2: Active tab invariant
+
+*For any* `WalletFlowState` value passed as the `state` prop, exactly one tab SHALL
+have `aria-selected="true"` and the gold active styles (`bg-[#c9a962]`, dark text),
+and all other tabs SHALL have `aria-selected="false"` and the muted inactive styles
+(transparent background, `#777777` text).
+
+**Validates: Requirements 2.1, 2.2, 2.3, 2.4, 6.1, 6.3**
+
+---
+
+### Property 3: Click fires onStateChange with correct value
+
+*For any* tab in the StateSwitcher (whether or not it is currently active), clicking
+it SHALL invoke `onStateChange` exactly once with the `WalletFlowState` value that
+corresponds to that tab's label.
+
+**Validates: Requirements 3.1, 3.3**
+
+---
+
+### Property 4: Arrow key navigation wraps correctly
+
+*For any* tab that currently has focus, pressing `ArrowRight` SHALL move focus to the
+tab at index `(currentIndex + 1) % 3`, and pressing `ArrowLeft` SHALL move focus to
+the tab at index `(currentIndex + 2) % 3` — both wrapping around the ends of the list.
+
+**Validates: Requirements 4.1, 4.2**
+
+---
+
+### Property 5: Enter and Space activate the focused tab
+
+*For any* tab that currently has focus, pressing `Enter` or `Space` SHALL invoke
+`onStateChange` with that tab's `WalletFlowState` value.
+
+**Validates: Requirements 4.3**
+
+---
+
+## Error Handling
+
+The StateSwitcher has a narrow surface area and no async operations, so error
+scenarios are limited:
+
+| Scenario | Handling |
+|---|---|
+| `state` prop is an unrecognised string | No tab will match; all tabs render as inactive. No crash. TypeScript prevents this at compile time. |
+| `onStateChange` is not provided | TypeScript enforces the prop as required; omitting it is a compile-time error. |
+| Component rendered in production without flag | Returns `null` silently — no error boundary needed. |
+| Focus management when component unmounts mid-navigation | Browser handles focus loss naturally; no cleanup required. |
+
+---
+
+## Testing Strategy
+
+### Dual Testing Approach
+
+Both unit tests and property-based tests are used. Unit tests cover specific examples
+and environment-gating behaviour; property-based tests verify universal invariants
+across all three states and all tab indices.
+
+### Property-Based Testing
+
+**Library**: [`fast-check`](https://github.com/dubzzz/fast-check) (already compatible
+with the project's TypeScript/Jest or Vitest setup).
+
+Each property test runs a minimum of **100 iterations**.
+
+Each test is tagged with a comment in the format:
+`// Feature: state-switcher, Property N: <property text>`
+
+| Property | Test description | Arbitrary |
+|---|---|---|
+| Property 1 | For any WalletFlowState, render produces exactly 3 tabs with correct labels | `fc.constantFrom("pre_connect", "connecting", "connected")` |
+| Property 2 | For any WalletFlowState, exactly one tab is active (aria-selected + styles) | same |
+| Property 3 | For any tab index (0–2), clicking it calls onStateChange with the right value | `fc.integer({ min: 0, max: 2 })` |
+| Property 4 | For any focused tab index and direction (left/right), focus lands on the correct next index | `fc.integer({ min: 0, max: 2 })` × `fc.constantFrom("ArrowLeft", "ArrowRight")` |
+| Property 5 | For any focused tab index and activation key (Enter/Space), onStateChange is called with the right value | `fc.integer({ min: 0, max: 2 })` × `fc.constantFrom("Enter", " ")` |
+
+### Unit Tests (Examples)
+
+- Renders `null` when `NODE_ENV === "production"` and flag is unset (Requirement 5.2)
+- Renders when `NODE_ENV === "development"` (Requirement 5.1)
+- Renders when `NEXT_PUBLIC_ENABLE_STATE_SWITCHER === "true"` regardless of `NODE_ENV` (Requirement 5.3)
+- Tab container has `role="tablist"` (Requirement 1.3)
+- All tabs are focusable (no `tabIndex=-1`, no `disabled`) (Requirement 4.4)
+- Label-to-value mapping: clicking "Pre Connect" → `"pre_connect"`, etc. (Requirement 1.2)

--- a/.kiro/specs/state-switcher/requirements.md
+++ b/.kiro/specs/state-switcher/requirements.md
@@ -1,0 +1,95 @@
+# Requirements Document
+
+## Introduction
+
+The StateSwitcher is a development/demo-only UI component that lets developers and
+reviewers manually cycle through the three wallet connection states of the
+Stellar-Spend dashboard — "Pre Connect", "Connecting", and "Connected" — without
+needing a real Stellar wallet. It renders as a tab-style control bar, updates the
+shared `WalletFlowState` used by the dashboard, and is hidden in production builds
+unless an explicit feature flag is set.
+
+## Glossary
+
+- **StateSwitcher**: The tab-style UI component defined in `src/components/StateSwitcher.tsx`.
+- **WalletFlowState**: The union type `"pre_connect" | "connecting" | "connected"` defined in `src/types/stellaramp.ts`.
+- **Dashboard**: The page and component tree rooted at `src/app/page.tsx` that renders the wallet UI.
+- **Active Tab**: The tab whose corresponding `WalletFlowState` value matches the currently selected state.
+- **Dev Mode**: The runtime condition where `process.env.NODE_ENV === "development"`.
+- **Feature Flag**: The environment variable `NEXT_PUBLIC_ENABLE_STATE_SWITCHER=true` that enables the component outside Dev Mode.
+- **Tab**: A single selectable option within the StateSwitcher representing one `WalletFlowState`.
+
+## Requirements
+
+### Requirement 1: Render Three State Tabs
+
+**User Story:** As a developer, I want a tab bar with "Pre Connect", "Connecting", and "Connected" options, so that I can switch between wallet states without a real wallet.
+
+#### Acceptance Criteria
+
+1. THE StateSwitcher SHALL render exactly three tabs with labels "Pre Connect", "Connecting", and "Connected".
+2. THE StateSwitcher SHALL map "Pre Connect" to `WalletFlowState` value `"pre_connect"`, "Connecting" to `"connecting"`, and "Connected" to `"connected"`.
+3. THE StateSwitcher SHALL render the tab container with `role="tablist"`.
+4. THE StateSwitcher SHALL render each tab as a `button` element with `role="tab"`.
+
+---
+
+### Requirement 2: Active Tab Visual Indicator
+
+**User Story:** As a developer, I want the active tab to be visually distinct, so that I can immediately see which state is currently selected.
+
+#### Acceptance Criteria
+
+1. WHEN a tab is the Active Tab, THE StateSwitcher SHALL apply a gold background (`#c9a962`) and dark text (`#0a0a0a`) to that tab.
+2. WHEN a tab is not the Active Tab, THE StateSwitcher SHALL render it with a transparent background and muted text (`#777777`).
+3. WHEN a tab is the Active Tab, THE StateSwitcher SHALL set `aria-selected="true"` on that tab's `button` element.
+4. WHEN a tab is not the Active Tab, THE StateSwitcher SHALL set `aria-selected="false"` on that tab's `button` element.
+
+---
+
+### Requirement 3: State Switching on Interaction
+
+**User Story:** As a developer, I want clicking a tab to update the dashboard wallet state, so that all connected components reflect the new state immediately.
+
+#### Acceptance Criteria
+
+1. WHEN a tab is clicked, THE StateSwitcher SHALL invoke the `onStateChange` callback with the corresponding `WalletFlowState` value.
+2. WHEN `onStateChange` is called, THE Dashboard SHALL update the displayed wallet state across all dependent components (Header, FormCard, RightPanel).
+3. WHEN the same Active Tab is clicked again, THE StateSwitcher SHALL invoke `onStateChange` with the same value without side effects.
+
+---
+
+### Requirement 4: Keyboard Accessibility
+
+**User Story:** As a developer, I want to navigate and activate tabs using only the keyboard, so that the component meets accessibility standards.
+
+#### Acceptance Criteria
+
+1. WHEN a tab has focus and the `ArrowRight` key is pressed, THE StateSwitcher SHALL move focus to the next tab, wrapping from the last tab to the first.
+2. WHEN a tab has focus and the `ArrowLeft` key is pressed, THE StateSwitcher SHALL move focus to the previous tab, wrapping from the first tab to the last.
+3. WHEN a tab has focus and the `Enter` or `Space` key is pressed, THE StateSwitcher SHALL invoke `onStateChange` with that tab's `WalletFlowState` value.
+4. THE StateSwitcher SHALL ensure each tab is reachable via the `Tab` key when the component is visible.
+
+---
+
+### Requirement 5: Development/Demo-Only Visibility
+
+**User Story:** As a developer, I want the StateSwitcher to be hidden in production, so that end users never see the debug control.
+
+#### Acceptance Criteria
+
+1. WHILE `NODE_ENV` is `"development"`, THE StateSwitcher SHALL render in the DOM.
+2. WHILE `NODE_ENV` is not `"development"` and `NEXT_PUBLIC_ENABLE_STATE_SWITCHER` is not `"true"`, THE StateSwitcher SHALL return `null` and render nothing.
+3. WHERE `NEXT_PUBLIC_ENABLE_STATE_SWITCHER` is `"true"`, THE StateSwitcher SHALL render regardless of `NODE_ENV`.
+
+---
+
+### Requirement 6: Controlled Component Interface
+
+**User Story:** As a developer, I want the StateSwitcher to accept its current state and a change handler as props, so that it integrates cleanly with the existing `useWalletFlow` hook.
+
+#### Acceptance Criteria
+
+1. THE StateSwitcher SHALL accept a `state` prop of type `WalletFlowState` that determines the Active Tab.
+2. THE StateSwitcher SHALL accept an `onStateChange` prop of type `(state: WalletFlowState) => void`.
+3. WHEN the `state` prop changes externally, THE StateSwitcher SHALL update the Active Tab to reflect the new value without internal state duplication.

--- a/.kiro/specs/state-switcher/tasks.md
+++ b/.kiro/specs/state-switcher/tasks.md
@@ -1,0 +1,93 @@
+# Implementation Plan: StateSwitcher
+
+## Overview
+
+Build a controlled, dev-only tab-bar component that lets developers cycle through `WalletFlowState` values, wire it into `page.tsx` via `useWalletFlow`, and gate its visibility with `NODE_ENV` / `NEXT_PUBLIC_ENABLE_STATE_SWITCHER`.
+
+## Tasks
+
+- [ ] 1. Create the `StateSwitcher` component
+  - Create `src/components/StateSwitcher.tsx` with the `StateSwitcherProps` interface (`state: WalletFlowState`, `onStateChange: (state: WalletFlowState) => void`)
+  - Define the static `TABS` array outside the component with labels and values matching Requirement 1.2
+  - Implement the visibility guard (`NODE_ENV` + `NEXT_PUBLIC_ENABLE_STATE_SWITCHER`) at the top of the render function
+  - Render a `<div role="tablist">` containing three `<button role="tab">` elements
+  - Apply gold background / dark text to the active tab and transparent / muted text to inactive tabs
+  - Set `aria-selected` correctly on each button
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 5.1, 5.2, 5.3, 6.1, 6.2, 6.3_
+
+- [ ] 2. Add keyboard navigation to `StateSwitcher`
+  - [ ] 2.1 Implement `ArrowRight` / `ArrowLeft` focus management using a `refs` array and wrap-around index arithmetic
+    - `ArrowRight`: `(currentIndex + 1) % 3`
+    - `ArrowLeft`: `(currentIndex + 2) % 3`
+    - Call `element.focus()` on the target button ref
+    - _Requirements: 4.1, 4.2, 4.4_
+
+  - [ ] 2.2 Implement `Enter` / `Space` activation in the same `onKeyDown` handler
+    - Call `onStateChange` with the focused tab's `WalletFlowState` value
+    - _Requirements: 4.3_
+
+  - [ ]* 2.3 Write property test for arrow key navigation (Property 4)
+    - **Property 4: Arrow key navigation wraps correctly**
+    - Arbitrary: `fc.integer({ min: 0, max: 2 })` × `fc.constantFrom("ArrowLeft", "ArrowRight")`
+    - Assert focus lands on `(index + 1) % 3` for `ArrowRight` and `(index + 2) % 3` for `ArrowLeft`
+    - **Validates: Requirements 4.1, 4.2**
+
+  - [ ]* 2.4 Write property test for Enter/Space activation (Property 5)
+    - **Property 5: Enter and Space activate the focused tab**
+    - Arbitrary: `fc.integer({ min: 0, max: 2 })` × `fc.constantFrom("Enter", " ")`
+    - Assert `onStateChange` is called with the correct `WalletFlowState` for the focused tab
+    - **Validates: Requirements 4.3**
+
+- [ ] 3. Write property and unit tests for `StateSwitcher` rendering and interaction
+  - [ ]* 3.1 Write property test for tab count and labels (Property 1)
+    - **Property 1: Always renders exactly three tabs**
+    - Arbitrary: `fc.constantFrom("pre_connect", "connecting", "connected")`
+    - Assert exactly 3 `button[role="tab"]` elements with labels "Pre Connect", "Connecting", "Connected" in order
+    - **Validates: Requirements 1.1, 1.4**
+
+  - [ ]* 3.2 Write property test for active tab invariant (Property 2)
+    - **Property 2: Active tab invariant**
+    - Arbitrary: `fc.constantFrom("pre_connect", "connecting", "connected")`
+    - Assert exactly one tab has `aria-selected="true"` and active styles; all others have `aria-selected="false"` and inactive styles
+    - **Validates: Requirements 2.1, 2.2, 2.3, 2.4, 6.1, 6.3**
+
+  - [ ]* 3.3 Write property test for click callback (Property 3)
+    - **Property 3: Click fires onStateChange with correct value**
+    - Arbitrary: `fc.integer({ min: 0, max: 2 })`
+    - Assert clicking tab at index `i` calls `onStateChange` exactly once with `TABS[i].value`
+    - **Validates: Requirements 3.1, 3.3**
+
+  - [ ]* 3.4 Write unit tests for visibility gating and ARIA structure
+    - Renders `null` when `NODE_ENV === "production"` and flag is unset (Requirement 5.2)
+    - Renders when `NODE_ENV === "development"` (Requirement 5.1)
+    - Renders when `NEXT_PUBLIC_ENABLE_STATE_SWITCHER === "true"` regardless of `NODE_ENV` (Requirement 5.3)
+    - Tab container has `role="tablist"` (Requirement 1.3)
+    - All tabs are focusable (Requirement 4.4)
+    - Label-to-value mapping: "Pre Connect" → `"pre_connect"`, etc. (Requirement 1.2)
+
+- [ ] 4. Checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 5. Integrate `StateSwitcher` into `page.tsx`
+  - [ ] 5.1 Refactor `page.tsx` to use `useWalletFlow("pre_connect")` and derive `isConnected` / `isConnecting` boolean flags
+    - Wire `state` and `setState` from the hook into existing components (`Header`, `FormCard`, `RightPanel`) via the derived booleans
+    - _Requirements: 3.2, 6.1, 6.2_
+
+  - [ ] 5.2 Mount `<StateSwitcher state={state} onStateChange={setState} />` in the page layout
+    - Place it above or below the main content section
+    - No changes needed to `Header`, `FormCard`, or `RightPanel`
+    - _Requirements: 3.1, 3.2, 6.1, 6.2_
+
+- [ ] 6. Add `NEXT_PUBLIC_ENABLE_STATE_SWITCHER` to `.env.example`
+  - Append the variable with a comment explaining its purpose
+  - _Requirements: 5.3_
+
+- [ ] 7. Final checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- Each task references specific requirements for traceability
+- Property tests use `fast-check` with a minimum of 100 iterations per property
+- The component is stateless — `page.tsx` owns the single source of truth


### PR DESCRIPTION
spec: StateSwitcher — dev/demo wallet state tab switcher
Adds the full spec (requirements, design, tasks) for the StateSwitcher component. No implementation yet — this PR establishes the plan before code is written.

What's being built
A dev/demo-only tab bar (
StateSwitcher.tsx
) that lets developers manually switch between the three wallet states — "Pre Connect", "Connecting", "Connected" — without needing a real Stellar wallet connected.

Spec summary
Requirements (6):

3 tabs with correct ARIA roles (role="tablist", role="tab", aria-selected)
Active tab gets gold background (#c9a962), inactive tabs get muted text
Clicking a tab fires onStateChange and updates the full dashboard
Full keyboard nav: ArrowLeft/Right to move focus (with wrap), Enter/Space to activate
Hidden in production unless NEXT_PUBLIC_ENABLE_STATE_SWITCHER=true
Controlled component interface — integrates with existing useWalletFlow hook
Design decisions:

Fully stateless/controlled — page.tsx owns the WalletFlowState source of truth
Keyboard nav via a refs array + element.focus() with modular index arithmetic
Zero changes needed to Header, FormCard, or RightPanel
5 correctness properties defined for property-based testing with fast-check

Closes #48 