### PR TITLE
spec: add ui-form-primitives requirements, design, and tasks

### DIFF
--- a/.kiro/specs/ui-form-primitives/.config.kiro
+++ b/.kiro/specs/ui-form-primitives/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "98ad0956-8829-416a-a8fd-3b0794eab07f", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/ui-form-primitives/design.md
+++ b/.kiro/specs/ui-form-primitives/design.md
@@ -1,0 +1,319 @@
+# Design Document: UI Form Primitives
+
+## Overview
+
+Extract three reusable form primitive components — `InputField`, `SelectField`, and `Field` — from the monolithic `FormCard` component into `src/components/ui/`. Each primitive is a self-contained, fully-typed React component that shares a consistent visual language driven entirely by CSS custom properties defined in `globals.css`. After extraction, `FormCard` is refactored to import from `src/components/ui/` rather than defining these components locally.
+
+The project is a Next.js 15 / React 19 application written in TypeScript with Tailwind CSS v4. No new runtime dependencies are required; the extraction is purely a structural refactor.
+
+## Architecture
+
+The change is a pure extraction — no new data flows, no new API calls, no new state. The dependency graph shifts as follows:
+
+```mermaid
+graph TD
+    subgraph Before
+        FC[FormCard.tsx] -->|defines locally| IP[InputField]
+        FC -->|defines locally| SF[SelectField]
+        FC -->|defines locally| FD[Field]
+    end
+
+    subgraph After
+        FC2[FormCard.tsx] -->|imports from| UI[src/components/ui/index.ts]
+        UI --> IP2[InputField.tsx]
+        UI --> SF2[SelectField.tsx]
+        UI --> FD2[Field.tsx]
+    end
+```
+
+File layout after extraction:
+
+```
+src/components/ui/
+  index.ts          ← barrel export
+  InputField.tsx
+  SelectField.tsx
+  Field.tsx
+```
+
+`FormCard.tsx` continues to own all business logic (state, API calls, validation). The primitives are purely presentational.
+
+## Components and Interfaces
+
+### InputField
+
+Renders a labeled `<input>` with an optional inline suffix, error state, and disabled state.
+
+```typescript
+export interface InputFieldProps {
+  label: string;
+  id: string;
+  value: string;
+  onChange: (value: string) => void;
+  type?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  suffix?: string;
+  error?: string;
+  // Numeric / text variants
+  inputMode?: "numeric" | "decimal" | "text";
+  min?: string;
+  step?: string;
+  maxLength?: number;
+}
+```
+
+Key rendering rules:
+- `<label>` uses `var(--muted)` color, uppercase, 10px, `0.18em` letter-spacing.
+- `<input>` uses `var(--line)` border, `var(--bg)` background, IBM Plex Mono font, `min-h-[46px]`.
+- `focus-visible` ring uses `var(--accent)`.
+- When `suffix` is provided, the input gains `pr-20` and the suffix is absolutely positioned right.
+- When `error` is provided, border becomes `red-500/60` and an error message renders below.
+- When `disabled`, `opacity-40` and `cursor-not-allowed` are applied.
+
+### SelectField
+
+Renders a labeled native `<select>` with a custom chevron SVG, loading state, and disabled state.
+
+```typescript
+export interface SelectFieldProps {
+  label: string;
+  id: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: Array<{ value: string; label: string }>;
+  placeholder?: string;
+  disabled?: boolean;
+  loading?: boolean;
+}
+```
+
+Key rendering rules:
+- `<label>` identical to `InputField` label.
+- `<select>` uses `appearance-none`, `var(--line)` border, `var(--bg)` background, IBM Plex Mono, `min-h-[46px]`.
+- A custom chevron SVG (`<svg>` with a downward chevron path) is absolutely positioned on the right, replacing the native browser arrow.
+- When `loading` is `true`, the select is disabled and the placeholder option reads "Loading...".
+- When `value` is non-empty, text is `var(--text)`; when empty, placeholder is `var(--muted)`.
+- `focus-visible` ring uses `var(--accent)`.
+
+### Field
+
+Renders a labeled read-only display container with configurable tone.
+
+```typescript
+export type FieldTone = "muted" | "accent";
+
+export interface FieldProps {
+  label: string;
+  value: string;
+  tone?: FieldTone;        // defaults to "muted"
+  loading?: boolean;
+  placeholder?: string;    // defaults to "—"
+}
+```
+
+Key rendering rules:
+- `<span>` label identical to `InputField` label.
+- Display container uses `var(--line)` border, `var(--bg)` background, IBM Plex Mono, `min-h-[46px]`.
+- When `loading` is `true`, renders "Resolving..." in `var(--muted)`.
+- When `value` is non-empty and `tone === "accent"`, renders in `var(--accent)`.
+- When `value` is non-empty and `tone === "muted"` (or omitted), renders in `var(--muted)`.
+- When `value` is empty and not loading, renders `placeholder` in `var(--muted)`.
+
+### Barrel Export (`src/components/ui/index.ts`)
+
+```typescript
+export { InputField } from "./InputField";
+export type { InputFieldProps } from "./InputField";
+
+export { SelectField } from "./SelectField";
+export type { SelectFieldProps } from "./SelectField";
+
+export { Field } from "./Field";
+export type { FieldProps, FieldTone } from "./Field";
+```
+
+## Data Models
+
+No new data models are introduced. The only data structures are the TypeScript prop interfaces defined above. The `options` array type used by `SelectField` is an inline `Array<{ value: string; label: string }>` — no separate type alias is needed since it is fully described by `SelectFieldProps`.
+
+Design token reference (from `globals.css`):
+
+| Token | Value | Usage |
+|---|---|---|
+| `var(--bg)` | `#0a0a0a` | Input/select/field background |
+| `var(--line)` | `#333333` | Border color |
+| `var(--muted)` | `#777777` | Labels, placeholder text, muted tone |
+| `var(--accent)` | `#c9a962` | Focus ring, accent tone, error border |
+| `var(--text)` | `#ffffff` | Selected value text in SelectField |
+
+Font: `var(--font-ibm-plex-mono)` (mapped in `globals.css` `@theme` block to the Next.js font variable `--font-ibm-plex-mono-source`).
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Label styling is consistent across all three primitives
+
+*For any* valid props passed to `InputField`, `SelectField`, or `Field`, the rendered label element must carry the classes that produce `var(--muted)` color, uppercase transform, 10px font size, and `0.18em` letter-spacing (e.g. `text-[10px] tracking-[0.18em] text-[var(--muted)] uppercase`).
+
+**Validates: Requirements 1.2, 2.2, 3.2**
+
+---
+
+### Property 2: Container base styling is consistent across all three primitives
+
+*For any* valid props passed to `InputField`, `SelectField`, or `Field`, the interactive/display container element must carry classes that apply `var(--line)` border, `var(--bg)` background, IBM Plex Mono font, and a minimum height of 46px.
+
+**Validates: Requirements 1.3, 2.3, 3.3, 4.2, 4.3**
+
+---
+
+### Property 3: InputField suffix is rendered when provided
+
+*For any* `InputFieldProps` where `suffix` is a non-empty string, the rendered output must contain a span element with that exact suffix text and the `var(--muted)` color class; when `suffix` is absent, no such span should be present.
+
+**Validates: Requirements 1.4**
+
+---
+
+### Property 4: InputField error state changes border and shows message
+
+*For any* `InputFieldProps` where `error` is a non-empty string, the input element must carry the `border-red-500/60` class and the rendered output must contain an element displaying that exact error string; when `error` is absent, neither the error border class nor the error element should be present.
+
+**Validates: Requirements 1.5**
+
+---
+
+### Property 5: Disabled state applies opacity and cursor classes
+
+*For any* `InputFieldProps` or `SelectFieldProps` where `disabled` is `true`, the input/select element must carry `opacity-40` and `cursor-not-allowed`; when `disabled` is `false` or absent, those classes must not be present.
+
+**Validates: Requirements 1.6, 2.6**
+
+---
+
+### Property 6: SelectField always renders a chevron SVG
+
+*For any* valid `SelectFieldProps`, the rendered output must contain an SVG element positioned on the right side of the select, regardless of the values of other props.
+
+**Validates: Requirements 2.4**
+
+---
+
+### Property 7: SelectField loading state disables select and shows "Loading..."
+
+*For any* `SelectFieldProps` where `loading` is `true`, the select element must be disabled and the first option element must have the text "Loading..."; when `loading` is `false`, the placeholder option must show the provided `placeholder` text (or the default).
+
+**Validates: Requirements 2.5**
+
+---
+
+### Property 8: SelectField value presence determines text color class
+
+*For any* `SelectFieldProps` where `value` is a non-empty string, the select element must carry the `var(--text)` color class; when `value` is an empty string, the select element must carry the `var(--muted)` color class.
+
+**Validates: Requirements 2.7**
+
+---
+
+### Property 9: Field tone determines value text color
+
+*For any* `FieldProps` where `value` is non-empty and `loading` is `false`: when `tone` is `"accent"`, the value element must carry the `var(--accent)` color class; when `tone` is `"muted"` or omitted, the value element must carry the `var(--muted)` color class.
+
+**Validates: Requirements 3.4, 3.5**
+
+---
+
+### Property 10: Field loading state shows "Resolving..." instead of value
+
+*For any* `FieldProps` where `loading` is `true`, the rendered output must contain the text "Resolving..." styled in `var(--muted)` and must not render the `value` prop text.
+
+**Validates: Requirements 3.6**
+
+---
+
+### Property 11: Field empty value renders placeholder
+
+*For any* `FieldProps` where `value` is an empty string and `loading` is `false`, the rendered output must display the `placeholder` prop text (defaulting to `"—"`) in `var(--muted)` color.
+
+**Validates: Requirements 3.7**
+
+---
+
+### Property 12: Focus-visible ring uses accent color on all three primitives
+
+*For any* valid props passed to `InputField`, `SelectField`, or `Field`, the interactive element must carry a `focus-visible` ring class referencing `var(--accent)`.
+
+**Validates: Requirements 4.4**
+
+---
+
+## Error Handling
+
+These are purely presentational components with no async operations or external dependencies. Error handling is limited to:
+
+- **Invalid / missing props**: TypeScript enforces required props at compile time. No runtime guards are needed.
+- **`error` prop on `InputField`**: The component renders the error message as provided by the caller. It does not validate or transform the string.
+- **`loading` prop on `SelectField` and `Field`**: The component renders a loading placeholder; the caller is responsible for setting `loading` back to `false` when data arrives.
+- **Empty `options` array on `SelectField`**: The select renders with only the placeholder option. No error state is shown — the caller decides whether to show a loading or disabled state.
+- **Unknown `tone` value on `Field`**: TypeScript's union type `"muted" | "accent"` prevents invalid values at compile time. No runtime fallback is needed.
+
+## Testing Strategy
+
+### Dual Testing Approach
+
+Both unit tests and property-based tests are required. They are complementary:
+
+- **Unit tests** cover specific examples, integration points, and edge cases.
+- **Property tests** verify universal invariants across randomly generated inputs.
+
+### Property-Based Testing
+
+Library: **`fast-check`** (TypeScript-native, works with any test runner).
+
+Install: `npm install --save-dev fast-check`
+
+Each property test must run a minimum of **100 iterations** (fast-check default is 100; set explicitly via `{ numRuns: 100 }`).
+
+Each test must include a comment tag in the format:
+`// Feature: ui-form-primitives, Property N: <property_text>`
+
+Each correctness property from the design document maps to exactly one property-based test:
+
+| Design Property | Test file | fast-check arbitraries |
+|---|---|---|
+| P1: Label styling | `InputField.test.tsx`, `SelectField.test.tsx`, `Field.test.tsx` | `fc.record({ label: fc.string(), ... })` |
+| P2: Container base styling | same files | same |
+| P3: InputField suffix | `InputField.test.tsx` | `fc.string({ minLength: 1 })` for suffix |
+| P4: InputField error state | `InputField.test.tsx` | `fc.string({ minLength: 1 })` for error |
+| P5: Disabled state | `InputField.test.tsx`, `SelectField.test.tsx` | `fc.boolean()` for disabled |
+| P6: SelectField chevron | `SelectField.test.tsx` | full props record |
+| P7: SelectField loading | `SelectField.test.tsx` | `fc.boolean()` for loading |
+| P8: SelectField value color | `SelectField.test.tsx` | `fc.oneof(fc.constant(""), fc.string({ minLength: 1 }))` |
+| P9: Field tone color | `Field.test.tsx` | `fc.constantFrom("muted", "accent")` |
+| P10: Field loading | `Field.test.tsx` | `fc.boolean()` for loading |
+| P11: Field empty placeholder | `Field.test.tsx` | `fc.string()` for placeholder |
+| P12: Focus-visible ring | `InputField.test.tsx`, `SelectField.test.tsx`, `Field.test.tsx` | full props record |
+
+### Unit Tests
+
+Unit tests should focus on:
+
+- **Specific rendering examples**: render `InputField` with a known set of props and assert the exact DOM structure.
+- **FormCard integration**: render `FormCard` and assert it uses the extracted primitives (no local re-definitions).
+- **Barrel export**: import from `src/components/ui/index.ts` and assert all three components and their prop types are exported.
+- **Edge cases**: `suffix` with whitespace-only string, `error` with a very long message, `options` as an empty array, `Field` with `value=""` and no `placeholder` prop (should default to `"—"`).
+
+Unit tests should be kept minimal — property tests handle broad input coverage.
+
+### Test File Locations
+
+```
+src/components/ui/__tests__/
+  InputField.test.tsx
+  SelectField.test.tsx
+  Field.test.tsx
+  index.test.ts        ← barrel export + FormCard integration
+```

--- a/.kiro/specs/ui-form-primitives/requirements.md
+++ b/.kiro/specs/ui-form-primitives/requirements.md
@@ -1,0 +1,105 @@
+# Requirements Document
+
+## Introduction
+
+Extract three reusable form primitive components — `InputField`, `SelectField`, and `Field` — from the monolithic `FormCard` component into `src/components/ui/`. These primitives share a consistent visual language (IBM Plex Mono font, `var(--line)` borders, `var(--muted)` labels, 46px height) and must be fully typed with TypeScript interfaces so they can be composed across the application independently of `FormCard`.
+
+## Glossary
+
+- **InputField**: A labeled text/number input with an optional inline suffix, error state, and disabled state.
+- **SelectField**: A labeled native `<select>` element with a custom chevron SVG, loading state, and disabled state.
+- **Field**: A labeled read-only display element that renders a value in either muted or accent tone.
+- **UI_Library**: The collection of primitive components located at `src/components/ui/`.
+- **Design_Token**: A CSS custom property defined in `globals.css` (e.g. `var(--line)`, `var(--muted)`, `var(--accent)`).
+- **Disabled_State**: The visual and interactive state of a component when the `disabled` prop is `true`.
+- **Accent_Tone**: Text rendered in `var(--accent)` color (`#c9a962`).
+- **Muted_Tone**: Text rendered in `var(--muted)` color (`#777777`).
+
+---
+
+## Requirements
+
+### Requirement 1: InputField Component
+
+**User Story:** As a developer, I want a reusable `InputField` component, so that I can render a labeled bordered input with an optional suffix across any form in the app.
+
+#### Acceptance Criteria
+
+1. THE `InputField` SHALL accept a `label`, `id`, `value`, `onChange`, `type`, `placeholder`, `disabled`, `suffix`, and `error` prop as defined by a TypeScript interface.
+2. THE `InputField` SHALL render a `<label>` element styled with `var(--muted)` color, uppercase, 10px font size, and `0.18em` letter-spacing.
+3. THE `InputField` SHALL render a `<input>` element with a `var(--line)` border, `var(--bg)` background, IBM Plex Mono font, and a minimum height of 46px.
+4. WHEN the `suffix` prop is provided, THE `InputField` SHALL render the suffix text absolutely positioned on the right side of the input, styled in `var(--muted)` color.
+5. WHEN the `error` prop is provided, THE `InputField` SHALL render the border in `red-500/60` and display the error message below the input in 10px red text.
+6. WHEN the `disabled` prop is `true`, THE `InputField` SHALL render with `opacity-40` and `cursor-not-allowed` on the input element.
+7. THE `InputField` SHALL accept optional `inputMode`, `min`, `step`, and `maxLength` props to support numeric and text input variants.
+
+---
+
+### Requirement 2: SelectField Component
+
+**User Story:** As a developer, I want a reusable `SelectField` component, so that I can render a labeled styled native select with a custom chevron across any form in the app.
+
+#### Acceptance Criteria
+
+1. THE `SelectField` SHALL accept a `label`, `id`, `value`, `onChange`, `options`, `placeholder`, `disabled`, and `loading` prop as defined by a TypeScript interface.
+2. THE `SelectField` SHALL render a `<label>` element styled identically to the `InputField` label (muted color, uppercase, 10px, 0.18em tracking).
+3. THE `SelectField` SHALL render a `<select>` element with `appearance-none`, a `var(--line)` border, `var(--bg)` background, IBM Plex Mono font, and a minimum height of 46px.
+4. THE `SelectField` SHALL render a custom chevron SVG icon absolutely positioned on the right side of the select, styled in `var(--muted)` color, replacing the native browser arrow.
+5. WHEN the `loading` prop is `true`, THE `SelectField` SHALL disable the select element and display "Loading..." as the placeholder option text.
+6. WHEN the `disabled` prop is `true`, THE `SelectField` SHALL render with `opacity-40` and `cursor-not-allowed` on the select element.
+7. WHEN a value is selected, THE `SelectField` SHALL render the selected text in `var(--text)` color; WHEN no value is selected, THE `SelectField` SHALL render the placeholder in `var(--muted)` color.
+8. THE `options` prop SHALL be typed as `Array<{ value: string; label: string }>`.
+
+---
+
+### Requirement 3: Field Component
+
+**User Story:** As a developer, I want a reusable `Field` component, so that I can display a labeled read-only value with configurable tone across any form in the app.
+
+#### Acceptance Criteria
+
+1. THE `Field` SHALL accept a `label`, `value`, `tone`, `loading`, and `placeholder` prop as defined by a TypeScript interface.
+2. THE `Field` SHALL render a `<span>` label element styled identically to the `InputField` label (muted color, uppercase, 10px, 0.18em tracking).
+3. THE `Field` SHALL render a read-only display container with a `var(--line)` border, `var(--bg)` background, IBM Plex Mono font, and a minimum height of 46px.
+4. WHEN the `tone` prop is `"accent"`, THE `Field` SHALL render the value text in `var(--accent)` color.
+5. WHEN the `tone` prop is `"muted"` or is omitted, THE `Field` SHALL render the value text in `var(--muted)` color.
+6. WHEN the `loading` prop is `true`, THE `Field` SHALL render a "Resolving..." placeholder in `var(--muted)` color instead of the value.
+7. WHEN the `value` prop is an empty string and `loading` is `false`, THE `Field` SHALL render the `placeholder` prop text (defaulting to `"—"`) in `var(--muted)` color.
+
+---
+
+### Requirement 4: Shared Visual Consistency
+
+**User Story:** As a developer, I want all three primitives to share a consistent visual language, so that forms composed from these components look cohesive without additional styling.
+
+#### Acceptance Criteria
+
+1. THE `UI_Library` SHALL use only Design_Tokens (`var(--line)`, `var(--muted)`, `var(--accent)`, `var(--bg)`, `var(--text)`) for colors, not hardcoded hex values.
+2. THE `InputField`, `SelectField`, and `Field` SHALL each render with a minimum height of 46px for their interactive/display area.
+3. THE `InputField`, `SelectField`, and `Field` SHALL each apply IBM Plex Mono font via the project's `--font-ibm-plex-mono` CSS variable or Tailwind font utility.
+4. THE `InputField`, `SelectField`, and `Field` SHALL each include a `focus-visible` ring styled in `var(--accent)` color for keyboard accessibility.
+
+---
+
+### Requirement 5: TypeScript Interfaces and Exports
+
+**User Story:** As a developer, I want all component props to be typed and exported, so that consuming components get full type safety and IDE autocompletion.
+
+#### Acceptance Criteria
+
+1. THE `UI_Library` SHALL export a named TypeScript interface for each component's props: `InputFieldProps`, `SelectFieldProps`, and `FieldProps`.
+2. THE `UI_Library` SHALL export each component as a named export from `src/components/ui/index.ts`.
+3. WHEN a required prop is missing, THE TypeScript compiler SHALL produce a type error at the call site.
+4. THE `FieldProps` interface SHALL define `tone` as a union type `"muted" | "accent"` with a default of `"muted"`.
+
+---
+
+### Requirement 6: FormCard Refactoring
+
+**User Story:** As a developer, I want `FormCard` to consume the extracted primitives from `src/components/ui/`, so that there is a single source of truth for each form primitive.
+
+#### Acceptance Criteria
+
+1. WHEN the extraction is complete, THE `FormCard` SHALL import `InputField`, `SelectField`, and `Field` from `src/components/ui/` instead of defining them locally.
+2. THE `FormCard` SHALL produce identical visual output before and after the refactoring.
+3. THE `FormCard` SHALL NOT contain local re-definitions of `InputField`, `SelectField`, or `Field` after the refactoring.

--- a/.kiro/specs/ui-form-primitives/tasks.md
+++ b/.kiro/specs/ui-form-primitives/tasks.md
@@ -1,0 +1,116 @@
+# Implementation Plan: UI Form Primitives
+
+## Overview
+
+Extract `InputField`, `SelectField`, and `Field` from `FormCard.tsx` into `src/components/ui/`, wire them back into `FormCard`, and add property-based and unit tests.
+
+## Tasks
+
+- [ ] 1. Set up `src/components/ui/` directory and CSS design tokens
+  - Verify `globals.css` defines `--bg`, `--line`, `--muted`, `--accent`, `--text`, and `--font-ibm-plex-mono` tokens; add any that are missing
+  - Create the `src/components/ui/` directory (empty placeholder or `index.ts` stub)
+  - _Requirements: 4.1, 4.3_
+
+- [ ] 2. Implement `InputField` component
+  - [ ] 2.1 Create `src/components/ui/InputField.tsx`
+    - Export `InputFieldProps` interface and `InputField` named component
+    - Render `<label>` with `text-[10px] tracking-[0.18em] text-[var(--muted)] uppercase`
+    - Render `<input>` with `border-[var(--line)] bg-[var(--bg)] font-[var(--font-ibm-plex-mono)] min-h-[46px]`
+    - Apply `pr-20` + absolutely-positioned suffix span when `suffix` is provided
+    - Apply `border-red-500/60` + error message element when `error` is provided
+    - Apply `opacity-40 cursor-not-allowed` when `disabled` is `true`
+    - Include `focus-visible:ring-1 focus-visible:ring-[var(--accent)]`
+    - Support optional `inputMode`, `min`, `step`, `maxLength` props
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 4.1, 4.2, 4.3, 4.4, 5.1_
+
+  - [ ]* 2.2 Write property test for `InputField` (P1, P2, P3, P4, P5, P12)
+    - **Property 1: Label styling is consistent** — `fc.record({ label: fc.string(), id: fc.string(), value: fc.string(), onChange: fc.constant(() => {}) })`
+    - **Property 2: Container base styling is consistent** — same arbitrary
+    - **Property 3: Suffix rendered when provided** — add `fc.string({ minLength: 1 })` for suffix
+    - **Property 4: Error state changes border and shows message** — `fc.string({ minLength: 1 })` for error
+    - **Property 5: Disabled state applies opacity/cursor** — `fc.boolean()` for disabled
+    - **Property 12: Focus-visible ring uses accent** — full props record
+    - File: `src/components/ui/__tests__/InputField.test.tsx`
+    - _Requirements: 1.2, 1.3, 1.4, 1.5, 1.6, 4.4_
+
+- [ ] 3. Implement `SelectField` component
+  - [ ] 3.1 Create `src/components/ui/SelectField.tsx`
+    - Export `SelectFieldProps` interface and `SelectField` named component
+    - Render `<label>` identically to `InputField` label
+    - Render `<select>` with `appearance-none border-[var(--line)] bg-[var(--bg)] font-[var(--font-ibm-plex-mono)] min-h-[46px]`
+    - Render a custom chevron `<svg>` absolutely positioned on the right (replaces native arrow)
+    - When `loading` is `true`, disable select and set placeholder option text to "Loading..."
+    - Apply `opacity-40 cursor-not-allowed` when `disabled` is `true`
+    - Apply `text-[var(--text)]` when value is non-empty; `text-[var(--muted)]` when empty
+    - Include `focus-visible:ring-1 focus-visible:ring-[var(--accent)]`
+    - Type `options` as `Array<{ value: string; label: string }>`
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 4.1, 4.2, 4.3, 4.4, 5.1_
+
+  - [ ]* 3.2 Write property test for `SelectField` (P1, P2, P5, P6, P7, P8, P12)
+    - **Property 1: Label styling is consistent** — `fc.record({ label: fc.string(), id: fc.string(), value: fc.string(), onChange: fc.constant(() => {}), options: fc.constant([]) })`
+    - **Property 2: Container base styling is consistent** — same arbitrary
+    - **Property 5: Disabled state** — `fc.boolean()` for disabled
+    - **Property 6: Chevron SVG always rendered** — full props record
+    - **Property 7: Loading state disables select and shows "Loading..."** — `fc.boolean()` for loading
+    - **Property 8: Value presence determines text color** — `fc.oneof(fc.constant(""), fc.string({ minLength: 1 }))` for value
+    - **Property 12: Focus-visible ring uses accent** — full props record
+    - File: `src/components/ui/__tests__/SelectField.test.tsx`
+    - _Requirements: 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 4.4_
+
+- [ ] 4. Implement `Field` component
+  - [ ] 4.1 Create `src/components/ui/Field.tsx`
+    - Export `FieldTone` union type, `FieldProps` interface, and `Field` named component
+    - Render `<span>` label identically to `InputField` label
+    - Render read-only display container with `border-[var(--line)] bg-[var(--bg)] font-[var(--font-ibm-plex-mono)] min-h-[46px]`
+    - When `loading` is `true`, render "Resolving..." in `var(--muted)`
+    - When `value` is non-empty and `tone === "accent"`, render value in `var(--accent)`
+    - When `value` is non-empty and `tone === "muted"` (or omitted), render value in `var(--muted)`
+    - When `value` is empty and not loading, render `placeholder` (default `"—"`) in `var(--muted)`
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 4.1, 4.2, 4.3, 5.1, 5.4_
+
+  - [ ]* 4.2 Write property test for `Field` (P1, P2, P9, P10, P11, P12)
+    - **Property 1: Label styling is consistent** — `fc.record({ label: fc.string(), value: fc.string() })`
+    - **Property 2: Container base styling is consistent** — same arbitrary
+    - **Property 9: Tone determines value text color** — `fc.constantFrom("muted", "accent")` for tone, `fc.string({ minLength: 1 })` for value
+    - **Property 10: Loading shows "Resolving..." not value** — `fc.boolean()` for loading
+    - **Property 11: Empty value renders placeholder** — `fc.string()` for placeholder, `fc.constant("")` for value
+    - **Property 12: Focus-visible ring uses accent** — full props record
+    - File: `src/components/ui/__tests__/Field.test.tsx`
+    - _Requirements: 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 4.4_
+
+- [ ] 5. Create barrel export and install fast-check
+  - [ ] 5.1 Create `src/components/ui/index.ts` with named exports for all three components and their prop types
+    - Export `InputField`, `InputFieldProps`
+    - Export `SelectField`, `SelectFieldProps`
+    - Export `Field`, `FieldProps`, `FieldTone`
+    - _Requirements: 5.1, 5.2_
+
+  - [ ]* 5.2 Write barrel export unit test
+    - Import all three components and prop types from `src/components/ui/index.ts` and assert they are defined
+    - File: `src/components/ui/__tests__/index.test.ts`
+    - _Requirements: 5.2_
+
+- [ ] 6. Checkpoint — ensure components compile cleanly
+  - Run `getDiagnostics` on all four new files; fix any TypeScript errors before proceeding.
+
+- [ ] 7. Refactor `FormCard` to use extracted primitives
+  - [ ] 7.1 Remove local `InputField`, `SelectField`, and `Field` definitions from `src/components/FormCard.tsx`
+    - Add import: `import { InputField, SelectField, Field } from "@/components/ui"`
+    - Delete the three local component function definitions and their prop interfaces
+    - Verify all existing usages in `FormCard` still compile and render identically
+    - _Requirements: 6.1, 6.2, 6.3_
+
+  - [ ]* 7.2 Write FormCard integration unit test
+    - Render `FormCard` with minimal required props and assert it does not define `InputField`, `SelectField`, or `Field` locally (import-level check)
+    - File: `src/components/ui/__tests__/index.test.ts` (append to existing file)
+    - _Requirements: 6.1, 6.3_
+
+- [ ] 8. Final checkpoint — ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- Each task references specific requirements for traceability
+- Property tests use `fast-check`; install with `npm install --save-dev fast-check` before running tests
+- All color values must use CSS custom properties (`var(--...)`) — no hardcoded hex values


### PR DESCRIPTION
spec: UI Form Primitives — extract reusable form components
Adds the full spec (requirements, design, tasks) for extracting InputField, SelectField, and Field from FormCard into src/components/ui/. No implementation yet.

What's being built
Three reusable, fully-typed form primitive components extracted from the monolithic FormCard into a shared UI library at src/components/ui/. After extraction, FormCard imports from the new barrel rather than defining them locally.

Spec summary
Requirements (6):

InputField — label + bordered input, optional suffix, error state, disabled
SelectField — label + native select, custom chevron SVG, loading state, disabled
Field — label + read-only display, "muted" | "accent" tone, loading/placeholder
Shared visual language — design tokens only (var(--line), var(--muted), var(--accent)), 46px height, IBM Plex Mono, focus-visible ring
TypeScript interfaces exported from 
index.ts
FormCard refactored to consume the new primitives with identical visual output
Design decisions:

Pure extraction — no new data flows, no new deps, no new state
All styling via CSS custom properties — zero hardcoded hex values
12 correctness properties defined covering every visual invariant
Property-based tests via fast-check (100 iterations each) + minimal unit tests
Tasks (8): Token setup → InputField → SelectField → Field → barrel export → compile checkpoint → FormCard refactor → final checkpoint.

Closes #49 