### PR TITLE
fix(#85): implement GET /api/offramp/institutions/[currency]

### DIFF
--- a/src/app/api/offramp/institutions/[currency]/route.ts
+++ b/src/app/api/offramp/institutions/[currency]/route.ts
@@ -1,88 +1,67 @@
 import { NextResponse } from 'next/server';
+import { env } from '@/lib/env';
 
 export const maxDuration = 10;
 
-const PAYCREST_API_URL = process.env.PAYCREST_API_URL || 'https://api.paycrest.io/v1';
+interface PaycrestHttpError extends Error {
+  status: number;
+}
 
-/**
- * GET /api/offramp/institutions/[currency]
- * 
- * Fetches available banks/institutions for a given currency from Paycrest API.
- */
-export async function GET(_req: Request, { params }: { params: Promise<{ currency: string }> }) {
-  try {
-    const { currency } = await params;
-    const apiKey = process.env.PAYCREST_API_KEY;
+class PaycrestAdapter {
+  private apiKey: string;
+  private apiUrl = 'https://api.paycrest.io/v1';
 
-    if (!apiKey) {
-      console.warn('PAYCREST_API_KEY not configured, returning default institutions');
-      // Return default Nigerian banks as fallback
-      return NextResponse.json([
-        { code: '044', name: 'Access Bank' },
-        { code: '023', name: 'Citibank' },
-        { code: '058', name: 'Diamond Bank' },
-        { code: '070', name: 'Fidelity Bank' },
-        { code: '011', name: 'First Bank of Nigeria' },
-        { code: '214', name: 'First City Monument Bank' },
-        { code: '058', name: 'Guaranty Trust Bank' },
-        { code: '076', name: 'Heritage Bank' },
-        { code: '082', name: 'Keystone Bank' },
-        { code: '101', name: 'Oceanic Bank' },
-        { code: '039', name: 'Stanbic IBTC Bank' },
-        { code: '232', name: 'Sterling Bank' },
-        { code: '068', name: 'United Bank for Africa' },
-        { code: '032', name: 'Union Bank of Nigeria' },
-        { code: '033', name: 'Unity Bank' },
-        { code: '215', name: 'Unity Bank' },
-        { code: '035', name: 'Wema Bank' },
-        { code: '057', name: 'Zenith Bank' },
-      ]);
-    }
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
 
-    const response = await fetch(`${PAYCREST_API_URL}/institutions/${encodeURIComponent(currency)}`, {
-      headers: {
-        'Authorization': `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-    });
-
-    if (!response.ok) {
-      const error = await response.text();
-      console.error('Paycrest API error (institutions):', response.status, error);
-      // Return default institutions on error
-      return NextResponse.json([
-        { code: '044', name: 'Access Bank' },
-        { code: '011', name: 'First Bank of Nigeria' },
-        { code: '058', name: 'Guaranty Trust Bank' },
-        { code: '068', name: 'United Bank for Africa' },
-        { code: '057', name: 'Zenith Bank' },
-      ]);
-    }
+  async getInstitutions(currency: string) {
+    const response = await fetch(
+      `${this.apiUrl}/institutions/${encodeURIComponent(currency)}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'API-Key': this.apiKey,
+        },
+      }
+    );
 
     const data = await response.json();
 
-    // Transform Paycrest response to our format
-    // Expected format: { institutions: [{ code, name, ... }] }
-    const institutions = Array.isArray(data)
-      ? data.map((i: { code?: string; bankCode?: string; name?: string; bankName?: string }) => ({
-        code: i.code || i.bankCode || '',
-        name: i.name || i.bankName || '',
-      }))
-      : data.institutions?.map((i: { code?: string; bankCode?: string; name?: string; bankName?: string }) => ({
-        code: i.code || i.bankCode || '',
-        name: i.name || i.bankName || '',
-      })) || [];
+    if (!response.ok) {
+      const error = new Error(
+        data?.message ?? `Failed to fetch institutions: ${response.status}`
+      ) as PaycrestHttpError;
+      error.status = response.status;
+      throw error;
+    }
+
+    return Array.isArray(data) ? data : (data.institutions ?? []);
+  }
+}
+
+export async function GET(_req: Request, { params }: { params: Promise<{ currency: string }> }) {
+  const { currency } = await params;
+
+  try {
+    const paycrest = new PaycrestAdapter(env.server.PAYCREST_API_KEY);
+    const institutions = await paycrest.getInstitutions(currency);
 
     return NextResponse.json(institutions);
-  } catch (error) {
-    console.error('Error fetching institutions from Paycrest:', error);
-    // Return default institutions on exception
-    return NextResponse.json([
-      { code: '044', name: 'Access Bank' },
-      { code: '011', name: 'First Bank of Nigeria' },
-      { code: '058', name: 'Guaranty Trust Bank' },
-      { code: '068', name: 'United Bank for Africa' },
-      { code: '057', name: 'Zenith Bank' },
-    ]);
+  } catch (err: unknown) {
+    console.error('Error fetching institutions from Paycrest:', err);
+
+    if (err instanceof Error && 'status' in err) {
+      const httpError = err as PaycrestHttpError;
+      if (httpError.status === 400 || httpError.status === 404) {
+        return NextResponse.json(
+          { error: `Unsupported currency: ${currency}` },
+          { status: 400 }
+        );
+      }
+      return NextResponse.json({ error: err.message }, { status: httpError.status });
+    }
+
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }


### PR DESCRIPTION
Closes #85 

## What changed
Rewrote the `GET /api/offramp/institutions/[currency]` route which previously had a broken stub implementation.

## Changes
- Replaced `process.env.PAYCREST_API_KEY` with `env.server.PAYCREST_API_KEY` (consistent with all other routes)
- Fixed auth header from `Authorization: Bearer` to `API-Key` (correct Paycrest scheme)
- Returns a raw array on success — matches what `FormCard.tsx` expects (`if (Array.isArray(data)) setInstitutions(data)`)
- Returns HTTP 400 with `{ error: "Unsupported currency: XYZ" }` when Paycrest responds 400/404
- Returns HTTP 500 with `{ error: "Internal server error" }` on unexpected errors
- Removed hardcoded fallback bank lists that were silently masking errors

## Testing
- `GET /api/offramp/institutions/NGN` → `[{ code, name }, ...]` with HTTP 200
- `GET /api/offramp/institutions/XYZ` → `{ error: "Unsupported currency: XYZ" }` with HTTP 400

- Replace stub with proper PaycrestAdapter using env.server.PAYCREST_API_KEY
- Use correct API-Key auth header (consistent with other routes)
- Return raw array (matches FormCard.tsx client expectation)
- Return 400 with 'Unsupported currency: {code}' on Paycrest 400/404
- Return 500 on unexpected errors
- Remove hardcoded fallback bank lists