### PR TITLE
fix(#86): implement POST /api/offramp/verify-account

### DIFF
--- a/src/app/api/offramp/verify-account/route.ts
+++ b/src/app/api/offramp/verify-account/route.ts
@@ -1,94 +1,67 @@
 import { NextResponse } from 'next/server';
+import { env } from '@/lib/env';
 
 export const maxDuration = 10;
 
-const PAYCREST_API_URL = process.env.PAYCREST_API_URL || 'https://api.paycrest.io/v1';
-
-interface VerifyAccountRequest {
-  institution: string;
-  accountIdentifier: string;
-  currency?: string;
+interface PaycrestHttpError extends Error {
+  status: number;
 }
 
-/**
- * POST /api/offramp/verify-account
- * 
- * Verifies a bank account via Paycrest API.
- * Returns the account holder's name if verification is successful.
- */
+class PaycrestAdapter {
+  private apiKey: string;
+  private apiUrl = 'https://api.paycrest.io/v1';
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  async verifyAccount(institution: string, accountIdentifier: string): Promise<string> {
+    const response = await fetch(`${this.apiUrl}/verify-account`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'API-Key': this.apiKey,
+      },
+      body: JSON.stringify({ institution, accountIdentifier }),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      const error = new Error(data?.message ?? `Verification failed: ${response.status}`) as PaycrestHttpError;
+      error.status = response.status;
+      throw error;
+    }
+
+    return data.accountName ?? data.data?.accountName ?? data.data?.account_name ?? String(data.data ?? '');
+  }
+}
+
 export async function POST(request: Request) {
   try {
-    const body: VerifyAccountRequest = await request.json();
-    const { institution, accountIdentifier, currency = 'NGN' } = body;
+    const body = await request.json();
+    const { institution, accountIdentifier } = body;
 
     if (!institution || !accountIdentifier) {
       return NextResponse.json(
-        { error: 'Institution and account identifier are required' },
+        { error: 'institution and accountIdentifier are required' },
         { status: 400 }
       );
     }
 
-    const apiKey = process.env.PAYCREST_API_KEY;
+    const paycrest = new PaycrestAdapter(env.server.PAYCREST_API_KEY);
+    const accountName = await paycrest.verifyAccount(institution, accountIdentifier);
 
-    if (!apiKey) {
-      console.warn('PAYCREST_API_KEY not configured, cannot verify account');
-      // Return mock response for development
-      return NextResponse.json({
-        accountName: '',
-        valid: false,
-        message: 'Account verification not available',
-      });
+    return NextResponse.json({ accountName });
+  } catch (err: unknown) {
+    console.error('Error verifying account via Paycrest:', err);
+
+    if (err instanceof Error && 'status' in err) {
+      const httpError = err as PaycrestHttpError;
+      const status = httpError.status >= 500 ? 502 : 400;
+      return NextResponse.json({ error: err.message }, { status });
     }
 
-    const response = await fetch(`${PAYCREST_API_URL}/verify-account`, {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        institution,
-        accountIdentifier,
-        currency,
-      }),
-    });
-
-    if (!response.ok) {
-      const error = await response.text();
-      console.error('Paycrest API error (verify-account):', response.status, error);
-
-      // Return empty account name for invalid accounts (not an error toast)
-      return NextResponse.json({
-        accountName: '',
-        valid: false,
-        message: 'Account verification failed',
-      });
-    }
-
-    const data = await response.json();
-
-    // Extract account name from Paycrest response
-    // Expected formats:
-    // - { accountName: "JOHN DOE" }
-    // - { data: { accountName: "JOHN DOE" } }
-    // - { data: "JOHN DOE" }
-    const accountName = data.accountName
-      ?? data.data?.accountName
-      ?? data.data?.account_name
-      ?? data.data
-      ?? '';
-
-    return NextResponse.json({
-      accountName: String(accountName),
-      valid: !!accountName,
-    });
-  } catch (error) {
-    console.error('Error verifying account via Paycrest:', error);
-    // Return empty account name for invalid accounts (not an error toast)
-    return NextResponse.json({
-      accountName: '',
-      valid: false,
-      message: 'Account verification failed',
-    });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }


### PR DESCRIPTION

Closes #86 

## What changed
Rewrote the `POST /api/offramp/verify-account` route which had a broken stub implementation.

## Changes
- Replaced `process.env.PAYCREST_API_KEY` with `env.server.PAYCREST_API_KEY` (consistent with all other routes)
- Fixed auth header from `Authorization: Bearer` to `API-Key` (correct Paycrest scheme)
- Returns `{ accountName }` on success — matches what `FormCard.tsx` expects (`data.accountName`)
- Returns HTTP 400 with `{ error: "institution and accountIdentifier are required" }` on missing fields
- Returns HTTP 400 on Paycrest client errors (4xx), HTTP 502 on Paycrest server errors (5xx)
- Returns HTTP 500 on unexpected errors
- Removed hardcoded mock fallbacks and silent error swallowing that masked failures

## Testing
- `POST` with valid `institution` + `accountIdentifier` → `{ accountName: "JOHN DOE" }` with HTTP 200
- `POST` with missing fields → `{ error: "institution and accountIdentifier are required" }` with HTTP 400
- `POST` with invalid account → HTTP 400 with Paycrest error message

- Replace process.env with env.server.PAYCREST_API_KEY
- Fix auth header from 'Authorization: Bearer' to 'API-Key'
- Return { accountName } matching FormCard.tsx client expectation
- Return 400 on missing fields or Paycrest client errors
- Return 502 on Paycrest 5xx errors
- Return 500 on unexpected errors
- Remove hardcoded mock fallbacks and silent error swallowing