### PR TITLE
fix(#87): implement POST /api/offramp/quote

### DIFF
--- a/src/app/api/offramp/quote/route.ts
+++ b/src/app/api/offramp/quote/route.ts
@@ -5,45 +5,22 @@ import { fetchPaycrestQuote, buildQuote, calculateBridgeAmount } from '@/lib/off
 
 export const maxDuration = 20;
 
-// Stablecoin fee in USDC (example: 0.5 USDC)
 const STABLECOIN_FEE = '0.5';
 
-/**
- * POST /api/offramp/quote
- * 
- * Fetches a quote for offramp transaction:
- * 1. Validates input amount
- * 2. Initializes Allbridge SDK (cached singleton)
- * 3. Calls getAllbridgeQuote to get receiveAmount
- * 4. If fee method is "stablecoin": subtracts fee from amount before quoting
- * 5. Fetches Paycrest rate for destination currency
- * 6. Calculates destination amount with 1% platform fee
- * 7. Validates and returns quote
- * 
- * Request body:
- * {
- *   amount: string (USDC amount)
- *   currency: string (destination currency code, e.g., 'NGN')
- *   feeMethod: 'native' | 'stablecoin'
- * }
- * 
- * Response:
- * {
- *   destinationAmount: string
- *   rate: number
- *   currency: string
- *   bridgeFee: string
- *   payoutFee: string
- *   estimatedTime: number
- * }
- */
+// Client sends "USDC" | "XLM"; build-tx route uses "stablecoin" | "native"
+const FEE_METHOD_MAP: Record<string, 'stablecoin' | 'native'> = {
+  USDC: 'stablecoin',
+  stablecoin: 'stablecoin',
+  XLM: 'native',
+  native: 'native',
+};
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const { amount, currency, feeMethod } = body;
 
-    // Validate input
-    if (!validateAmount(amount)) {
+    if (!validateAmount(String(amount ?? ''))) {
       return NextResponse.json(
         { error: 'Invalid amount: must be a positive number' },
         { status: 400 }
@@ -51,110 +28,74 @@ export async function POST(request: NextRequest) {
     }
 
     if (!currency || typeof currency !== 'string') {
+      return NextResponse.json({ error: 'currency is required' }, { status: 400 });
+    }
+
+    const normalizedFee = FEE_METHOD_MAP[feeMethod];
+    if (!normalizedFee) {
       return NextResponse.json(
-        { error: 'Invalid currency' },
+        { error: 'feeMethod must be "USDC", "XLM", "stablecoin", or "native"' },
         { status: 400 }
       );
     }
 
-    if (!['native', 'stablecoin'].includes(feeMethod)) {
-      return NextResponse.json(
-        { error: 'Invalid feeMethod: must be "native" or "stablecoin"' },
-        { status: 400 }
-      );
-    }
+    const bridgeAmount = normalizedFee === 'stablecoin'
+      ? calculateBridgeAmount(String(amount), 'stablecoin', STABLECOIN_FEE)
+      : String(amount);
 
-    // Calculate bridge amount based on fee method
-    let bridgeAmount = amount;
-    if (feeMethod === 'stablecoin') {
-      bridgeAmount = calculateBridgeAmount(amount, 'stablecoin', STABLECOIN_FEE);
-    }
+    // Initialize Allbridge SDK
+    let receiveAmount: string;
+    try {
+      const { AllbridgeCoreSdk, nodeRpcUrlsDefault } = await import('@allbridge/bridge-core-sdk');
 
-    // Initialize Allbridge SDK (cached singleton promise)
-    const { AllbridgeCoreSdk, nodeRpcUrlsDefault, ChainSymbol } = await import('@allbridge/bridge-core-sdk');
+      const sdk = new AllbridgeCoreSdk({
+        ...nodeRpcUrlsDefault,
+        sorobanNetworkPassphrase: 'Public Global Stellar Network ; September 2015',
+        ...(env.public.NEXT_PUBLIC_STELLAR_SOROBAN_RPC_URL && {
+          sorobanRpc: env.public.NEXT_PUBLIC_STELLAR_SOROBAN_RPC_URL,
+        }),
+        ...(env.server.BASE_RPC_URL && { ETH: env.server.BASE_RPC_URL }),
+      });
 
-    const sdk = new AllbridgeCoreSdk({
-      ...nodeRpcUrlsDefault,
-      sorobanNetworkPassphrase: 'Public Global Stellar Network ; September 2015',
-      ...(env.public.NEXT_PUBLIC_STELLAR_SOROBAN_RPC_URL && {
-        sorobanRpc: env.public.NEXT_PUBLIC_STELLAR_SOROBAN_RPC_URL,
-      }),
-      ...(env.server.BASE_RPC_URL && {
-        ETH: env.server.BASE_RPC_URL,
-      }),
-    });
+      const chainDetails = await sdk.chainDetailsMap();
+      let stellarChain: any = null;
+      let baseChain: any = null;
 
-    // Get chain details to find USDC tokens
-    const chainDetails = await sdk.chainDetailsMap();
-
-    // Find Stellar and Base chains
-    let stellarChain: any = null;
-    let baseChain: any = null;
-
-    for (const [, chain] of Object.entries(chainDetails)) {
-      const chainObj = chain as any;
-      if (chainObj.name?.toLowerCase().includes('stellar') || chainObj.name?.toLowerCase().includes('soroban')) {
-        stellarChain = chainObj;
+      for (const [, chain] of Object.entries(chainDetails)) {
+        const c = chain as any;
+        if (c.name?.toLowerCase().includes('stellar') || c.name?.toLowerCase().includes('soroban')) stellarChain = c;
+        if (c.name?.toLowerCase().includes('ethereum') || c.name?.toLowerCase().includes('base')) baseChain = c;
       }
-      if (chainObj.name?.toLowerCase().includes('ethereum') || chainObj.name?.toLowerCase().includes('base')) {
-        baseChain = chainObj;
-      }
+
+      if (!stellarChain || !baseChain) throw new Error('Chain details unavailable');
+
+      const stellarUsdc = stellarChain.tokens.find((t: any) => t.symbol === 'USDC');
+      const baseUsdc = baseChain.tokens.find((t: any) => t.symbol === 'USDC');
+
+      if (!stellarUsdc || !baseUsdc) throw new Error('USDC token not found');
+
+      receiveAmount = await sdk.getAmountToBeReceived(stellarUsdc, baseUsdc, bridgeAmount);
+    } catch {
+      return NextResponse.json({ error: 'Bridge quote unavailable' }, { status: 502 });
     }
 
-    if (!stellarChain || !baseChain) {
-      throw new Error('Failed to fetch chain details from Allbridge');
+    // Fetch Paycrest FX rate
+    let rate: number;
+    let destinationAmount: string;
+    try {
+      ({ rate, destinationAmount } = await fetchPaycrestQuote(receiveAmount, currency));
+    } catch {
+      return NextResponse.json({ error: 'FX rate unavailable' }, { status: 502 });
     }
 
-    // Find USDC tokens on both chains
-    const stellarUsdc = stellarChain.tokens.find((t: any) => t.symbol === 'USDC');
-    const baseUsdc = baseChain.tokens.find((t: any) => t.symbol === 'USDC');
-
-    if (!stellarUsdc || !baseUsdc) {
-      throw new Error('USDC token not found on one or both chains');
-    }
-
-    // Get quote from Allbridge for bridge transfer
-    // This returns the amount received on the destination chain (Base)
-    const receiveAmount = await sdk.getAmountToBeReceived(
-      stellarUsdc,
-      baseUsdc,
-      bridgeAmount
-    );
-
-    // Fetch Paycrest rate and calculate destination amount
-    const { rate, destinationAmount } = await fetchPaycrestQuote(receiveAmount, currency);
-
-    // Build and validate quote
-    const quote = buildQuote(
-      destinationAmount,
-      rate,
-      currency,
-      '0', // bridgeFee - would come from SDK if available
-      '0', // payoutFee - would come from SDK if available
-      300  // estimatedTime in seconds
-    );
-
+    const quote = buildQuote(destinationAmount, rate, currency, '0', '0', 300);
     return NextResponse.json(quote);
   } catch (error) {
     console.error('Quote fetch error:', error);
-
     const message = error instanceof Error ? error.message : 'Unknown error';
-
-    // Return appropriate error response
-    if (message.includes('Invalid')) {
+    if (message.includes('Invalid') || message.includes('less than')) {
       return NextResponse.json({ error: message }, { status: 400 });
     }
-
-    if (message.includes('Paycrest')) {
-      return NextResponse.json(
-        { error: 'Failed to fetch exchange rate' },
-        { status: 502 }
-      );
-    }
-
-    return NextResponse.json(
-      { error: 'Failed to generate quote' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to generate quote' }, { status: 500 });
   }
 }


### PR DESCRIPTION



Closes #87 

## What changed
Rewrote the `POST /api/offramp/quote` route which had several bugs preventing it from working.

## Changes
- Accept `feeMethod` as `"USDC"` or `"XLM"` (what `FormCard.tsx` actually sends) in addition to `"stablecoin"`/`"native"` — the old route rejected all client requests with a 400
- Wrap Allbridge SDK errors in HTTP 502 `{ error: "Bridge quote unavailable" }` (isolated try/catch)
- Wrap Paycrest errors in HTTP 502 `{ error: "FX rate unavailable" }` (isolated try/catch)
- Coerce `amount` to string before `validateAmount()` to handle both string and numeric input
- Response shape `{ destinationAmount, rate, currency, bridgeFee, payoutFee, estimatedTime }` matches `isValidQuote()` check in `FormCard.tsx`

## Key bug
The old route validated `feeMethod` against `['native', 'stablecoin']` but the client sends `"USDC"` or `"XLM"`, so every quote request returned HTTP 400.

## Testing
- `POST { amount: "1", currency: "NGN", feeMethod: "USDC" }` → valid quote with HTTP 200
- `POST { amount: "1", currency: "NGN", feeMethod: "XLM" }` → valid quote with HTTP 200
- `POST` with missing/invalid fields → HTTP 400 with error message
- Allbridge failure → HTTP 502 `{ error: "Bridge quote unavailable" }`
- Paycrest failure → HTTP 502 `{ error: "FX rate unavailable" }`

- Accept feeMethod as 'USDC'/'XLM' (client values) and 'stablecoin'/'native' (build-tx values)
- Wrap Allbridge errors in 502 'Bridge quote unavailable'
- Wrap Paycrest errors in 502 'FX rate unavailable'
- Coerce amount to string before validateAmount (handles numeric input)
- Return { destinationAmount, rate, currency, bridgeFee, payoutFee, estimatedTime } matching isValidQuote() shape expected by FormCard.tsx