### PR TITLE
fix(#88): implement POST /api/webhooks/paycrest

### DIFF
--- a/src/app/api/webhooks/paycrest/route.ts
+++ b/src/app/api/webhooks/paycrest/route.ts
@@ -1,13 +1,63 @@
 import { NextResponse } from 'next/server';
+import { env } from '@/lib/env';
+import type { PayoutStatus } from '@/lib/offramp/types';
 
 export const maxDuration = 10;
 
-// import { PAYCREST_WEBHOOK_SECRET } from '@/lib/env';
+function mapPaycrestStatus(eventType: string): PayoutStatus | null {
+  switch (eventType) {
+    case 'payment_order.pending':      return 'pending';
+    case 'payment_order.validated':    return 'validated';
+    case 'payment_order.settled':      return 'settled';
+    case 'payment_order.refunded':     return 'refunded';
+    case 'payment_order.expired':      return 'expired';
+    default:                           return null;
+  }
+}
 
-// TODO: handle Paycrest webhook events
-export async function POST() {
-  // Example of using the centralized env config
-  // const webhookSecret = PAYCREST_WEBHOOK_SECRET;
+async function verifySignature(rawBody: string, signature: string, secret: string): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const mac = await crypto.subtle.sign('HMAC', key, encoder.encode(rawBody));
+  const computed = Buffer.from(mac).toString('hex');
+  // Timing-safe comparison via fixed-length XOR
+  if (computed.length !== signature.length) return false;
+  let diff = 0;
+  for (let i = 0; i < computed.length; i++) {
+    diff |= computed.charCodeAt(i) ^ signature.charCodeAt(i);
+  }
+  return diff === 0;
+}
 
-  return NextResponse.json({ error: 'Not implemented' }, { status: 501 });
+export async function POST(request: Request) {
+  const rawBody = await request.text();
+  const signature = request.headers.get('X-Paycrest-Signature') ?? '';
+
+  const valid = await verifySignature(rawBody, signature, env.server.PAYCREST_WEBHOOK_SECRET);
+  if (!valid) {
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+  }
+
+  try {
+    const payload = JSON.parse(rawBody);
+    const { event, data } = payload;
+    const payoutOrderId: string = data?.id ?? data?.orderId ?? '';
+    const status = mapPaycrestStatus(event);
+
+    if (status && payoutOrderId) {
+      console.log(`Order ${payoutOrderId} status → ${status}`);
+    } else {
+      console.warn(`Paycrest webhook: unhandled event "${event}" for order "${payoutOrderId}"`);
+    }
+  } catch {
+    console.warn('Paycrest webhook: failed to parse payload');
+  }
+
+  return NextResponse.json({ received: true });
 }


### PR DESCRIPTION

Closes #88 


Description:
## What changed
Replaced the 501 stub with a fully working Paycrest webhook handler.

## Implementation
- Reads raw body via `request.text()` before any JSON parsing (required for HMAC integrity)
- Verifies `X-Paycrest-Signature` header using HMAC-SHA256 with `PAYCREST_WEBHOOK_SECRET` via the Web Crypto API
- Timing-safe comparison (character-by-character XOR) to prevent timing attacks
- Returns HTTP 401 `{ error: "Invalid signature" }` immediately on mismatch
- Maps Paycrest event types (`payment_order.pending/validated/settled/refunded/expired`) to internal `PayoutStatus`
- Logs `Order {id} status → {status}` for known events; warns on unknown events
- `TransactionStorage` is browser-only (localStorage) so server-side persistence is deferred — logging only as specified
- Returns HTTP 200 `{ received: true }` immediately after acknowledgement

## Notes
- `mapPaycrestStatus()` is defined inline in the route (it didn't exist anywhere in the codebase)
- Header name `X-Paycrest-Signature` follows Paycrest's standard webhook convention
- Verify HMAC-SHA256 signature from X-Paycrest-Signature header using PAYCREST_WEBHOOK_SECRET via Web Crypto API (timing-safe)
- Return 401 immediately on invalid signature
- Map Paycrest event types to internal PayoutStatus via mapPaycrestStatus()
- Log 'Order {id} status → {status}' on known events
- Log warning on unknown events or missing order ID
- Return 200 { received: true } immediately after acknowledgement
- Use request.text() for raw body (required for HMAC verification)