### PR TITLE
Implement PaycrestAdapter and update Soroban fee bumping logic

### DIFF
--- a/src/app/api/offramp/paycrest/order/[orderId]/route.ts
+++ b/src/app/api/offramp/paycrest/order/[orderId]/route.ts
@@ -3,38 +3,7 @@ import { env } from '@/lib/env';
 
 export const maxDuration = 10;
 
-interface PaycrestHttpError extends Error {
-  status: number;
-}
-
-class PaycrestAdapter {
-  private apiKey: string;
-  private apiUrl = 'https://api.paycrest.io/v1';
-
-  constructor(apiKey: string) {
-    this.apiKey = apiKey;
-  }
-
-  async getOrderStatus(orderId: string) {
-    const response = await fetch(`${this.apiUrl}/sender/orders/${orderId}`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        'API-Key': this.apiKey,
-      },
-    });
-
-    const data = await response.json();
-
-    if (!response.ok) {
-      const error = new Error(data?.message ?? 'Failed to fetch order status') as PaycrestHttpError;
-      error.status = response.status;
-      throw error;
-    }
-
-    return data;
-  }
-}
+import { PaycrestAdapter, PaycrestHttpError } from '@/lib/offramp/adapters/paycrest-adapter';
 
 /**
  * GET /api/offramp/paycrest/order/[orderId]

--- a/src/app/api/offramp/paycrest/order/route.ts
+++ b/src/app/api/offramp/paycrest/order/route.ts
@@ -5,54 +5,9 @@ import { generateRequestId, createRequestLogger } from '@/lib/offramp/utils/logg
 
 export const maxDuration = 20;
 
-interface PaycrestOrderRequest {
-  amount: number;
-  rate: number;
-  token: string;
-  network: string;
-  reference: string;
-  returnAddress: string;
-  recipient: {
-    institution: string;
-    accountIdentifier: string;
-    accountName: string;
-    currency: string;
-  };
-}
+import { PayoutOrderRequest } from '@/lib/offramp/types';
 
-interface PaycrestHttpError extends Error {
-  status: number;
-}
-
-class PaycrestAdapter {
-  private apiKey: string;
-  private apiUrl = 'https://api.paycrest.io/v1';
-
-  constructor(apiKey: string) {
-    this.apiKey = apiKey;
-  }
-
-  async createOrder(payload: PaycrestOrderRequest) {
-    const response = await fetch(`${this.apiUrl}/sender/orders`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'API-Key': this.apiKey,
-      },
-      body: JSON.stringify(payload),
-    });
-
-    const data = await response.json();
-
-    if (!response.ok) {
-      const error = new Error(data?.message ?? 'Failed to create Paycrest order') as PaycrestHttpError;
-      error.status = response.status;
-      throw error;
-    }
-
-    return data;
-  }
-}
+import { PaycrestAdapter, PaycrestHttpError } from '@/lib/offramp/adapters/paycrest-adapter';
 
 /**
  * POST /api/offramp/paycrest/order
@@ -182,7 +137,7 @@ export async function POST(req: NextRequest) {
       reference,
       returnAddress,
       recipient,
-    });
+    } as PayoutOrderRequest);
 
     const response = NextResponse.json({ data: order });
     response.headers.set('X-Request-Id', requestId);

--- a/src/lib/offramp/adapters/paycrest-adapter.ts
+++ b/src/lib/offramp/adapters/paycrest-adapter.ts
@@ -1,0 +1,135 @@
+import type { 
+  PayoutOrderRequest, 
+  PayoutOrderResponse, 
+  PayoutStatus 
+} from '../types';
+import { PayoutProviderAdapter } from './payout-provider';
+
+export class PaycrestHttpError extends Error {
+  constructor(
+    public message: string,
+    public status: number,
+    public details?: any
+  ) {
+    super(message);
+    this.name = 'PaycrestHttpError';
+  }
+}
+
+export class PaycrestAdapter implements PayoutProviderAdapter {
+  private apiUrl = 'https://api.paycrest.io/v1';
+
+  constructor(private apiKey: string) {}
+
+  /**
+   * Private fetch method with authentication and timeout
+   */
+  private async fetch(endpoint: string, options: RequestInit = {}) {
+    const url = `${this.apiUrl}${endpoint}`;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 15000);
+
+    try {
+      const response = await fetch(url, {
+        ...options,
+        headers: {
+          'API-Key': this.apiKey,
+          'Content-Type': 'application/json',
+          ...options.headers,
+        },
+        signal: controller.signal,
+      });
+
+      let data;
+      try {
+        data = await response.json();
+      } catch (e) {
+        // Fallback for non-JSON responses
+      }
+
+      if (!response.ok) {
+        throw new PaycrestHttpError(
+          data?.message || response.statusText || 'Unknown error',
+          response.status,
+          data
+        );
+      }
+
+      // Return data.data if it exists, otherwise return data
+      return data?.data ?? data;
+    } catch (error: any) {
+      if (error instanceof PaycrestHttpError) {
+        throw error;
+      }
+      
+      if (error.name === 'AbortError') {
+        throw new PaycrestHttpError('Request timeout', 504);
+      }
+      
+      // Map network errors to 502
+      throw new PaycrestHttpError(error.message || 'Network error', 502);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  /**
+   * Implement createOrder(request: PayoutOrderRequest)
+   */
+  async createOrder(request: PayoutOrderRequest): Promise<PayoutOrderResponse> {
+    return this.fetch('/sender/orders', {
+      method: 'POST',
+      body: JSON.stringify(request),
+    });
+  }
+
+  /**
+   * Implement getOrderStatus(orderId: string)
+   */
+  async getOrderStatus(orderId: string): Promise<{ status: PayoutStatus; id: string }> {
+    const response = await this.fetch(`/sender/orders/${orderId}`, {
+      method: 'GET',
+    });
+    
+    // Map response status to PayoutStatus type
+    return {
+      status: response.status as PayoutStatus,
+      id: response.id,
+    };
+  }
+
+  // PayoutProviderAdapter requirements
+  async getCurrencies(): Promise<Array<{ code: string; name: string; symbol: string }>> {
+    return this.fetch('/sender/currencies');
+  }
+
+  async getInstitutions(currency: string): Promise<Array<{ code: string; name: string }>> {
+    return this.fetch(`/sender/institutions/${currency}`);
+  }
+
+  async verifyAccount(institution: string, accountIdentifier: string): Promise<string> {
+    const response = await this.fetch('/sender/verify-account', {
+      method: 'POST',
+      body: JSON.stringify({ institution, accountIdentifier }),
+    });
+    return response.accountName;
+  }
+
+  async getRate(
+    token: string,
+    amount: string,
+    currency: string,
+    options?: { network?: string; providerId?: string }
+  ): Promise<number> {
+    const queryParams = new URLSearchParams({
+      token,
+      amount,
+      currency,
+      ...(options?.network && { network: options.network }),
+      ...(options?.providerId && { providerId: options.providerId }),
+    });
+    
+    const response = await this.fetch(`/sender/rate?${queryParams}`);
+    return response.rate;
+  }
+}

--- a/src/lib/offramp/adapters/soroban-tx-builder.ts
+++ b/src/lib/offramp/adapters/soroban-tx-builder.ts
@@ -132,14 +132,19 @@ export async function buildSwapAndBridgeTx(
     });
   }
 
-  // Assemble transaction with bumped fee (1.5x of base + minResourceFee)
+  // Compute and apply bumped fee logic per #146
+  const originalFee = parseInt(tx.fee);
+  const simMinFee = parseInt(simulationResponse.minResourceFee || '0');
+  const targetFee = Math.ceil((originalFee + simMinFee) * 1.5);
+  const preAssemblyFee = Math.max(targetFee - simMinFee, originalFee);
+
+  console.log(`[Fee Bump] originalFee: ${originalFee}, simMinFee: ${simMinFee}, targetFee: ${targetFee}, preAssemblyFee: ${preAssemblyFee}`);
+
+  // Mutate tx._fee before assembly to ensure resource fees are added correctly
+  (tx as any)._fee = preAssemblyFee.toString();
+
+  // Assemble transaction
   const assembledTx = StellarSdk.rpc.assembleTransaction(tx, simulationResponse);
-  
-  const baseFee = parseInt(assembledTx.fee);
-  const minResourceFee = parseInt(simulationResponse.minResourceFee || '0');
-  const bumpedFee = Math.ceil((baseFee + minResourceFee) * 1.5);
-  
-  assembledTx.fee = bumpedFee.toString();
 
   // Return base64 XDR
   return assembledTx.toXDR();

--- a/src/lib/offramp/types/index.ts
+++ b/src/lib/offramp/types/index.ts
@@ -45,6 +45,7 @@ export interface BeneficiaryInfo {
   accountName: string;
   currency: string;
   memo?: string;
+  metadata?: Record<string, any>;
 }
 
 export interface ExecuteRequest {
@@ -96,6 +97,7 @@ export interface PayoutOrderRequest {
   network: string;
   rate: number;
   recipient: BeneficiaryInfo;
+  reference: string;
   returnAddress: string;
 }
 


### PR DESCRIPTION
closes #149 
closes #148 
closes #147 
closes #146 

feat(paycrest, bridge): implement PaycrestAdapter and update fee bumping logic

- [Paycrest #147, #148, #149]: Implement PaycrestAdapter with standardized HTTP client, 
  auth, 15s timeout, and comprehensive error mapping.
- Add createOrder and getOrderStatus methods to PaycrestAdapter with mainnet endpoint integration.
- Update offramp types to include reference and metadata fields for payout orders.
- [Bridge #146]: Refactor Soroban transaction builder to implement 1.5x fee bumping 
  logic before transaction assembly to ensure reliability.
