### PR TITLE
feat: add real-time FX rate ticker in Header (#203)

### DIFF
--- a/src/app/api/offramp/rate/route.ts
+++ b/src/app/api/offramp/rate/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+
+export const maxDuration = 10;
+
+export async function GET() {
+  try {
+    const res = await fetch('https://api.paycrest.io/v1/rates/USDC/1/NGN?network=base', {
+      next: { revalidate: 0 },
+    });
+    if (!res.ok) return NextResponse.json({ error: 'unavailable' }, { status: 502 });
+    const data = await res.json();
+    const rate = parseFloat(data.rate ?? '0');
+    if (!rate || rate <= 0) return NextResponse.json({ error: 'invalid rate' }, { status: 502 });
+    return NextResponse.json({ rate });
+  } catch {
+    return NextResponse.json({ error: 'unavailable' }, { status: 502 });
+  }
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@
 import { cn } from "@/lib/cn";
 import { ThemeToggle } from "./ThemeToggle";
 import { CopyButton } from "./CopyButton";
+import { useFxRate } from "@/hooks/useFxRate";
 
 export interface HeaderProps {
   subtitle: string;
@@ -76,9 +77,11 @@ export function Header({
   onConnect,
   onDisconnect,
 }: HeaderProps) {
+  const { rate, flash } = useFxRate();
+
   return (
     <header className="w-full px-6 py-5 flex items-start justify-between gap-6 max-[720px]:flex-col max-[720px]:items-start" role="banner">
-      {/* Left: title + subtitle */}
+      {/* Left: title + subtitle + FX chip */}
       <div className="flex flex-col gap-1">
         <h1
           className="font-space-grotesk font-bold text-white leading-none tracking-tight"
@@ -87,6 +90,18 @@ export function Header({
           STELLAR-SPEND
         </h1>
         <p className="text-xs text-[#777777] tracking-widest uppercase">{subtitle}</p>
+        <span
+          aria-live="polite"
+          aria-label="Live FX rate"
+          className={cn(
+            "mt-1 inline-block self-start px-2 py-0.5 text-[10px] tracking-widest uppercase border border-[#c9a962]/40 text-[#c9a962] transition-colors duration-300",
+            flash && "bg-[#c9a962]/20"
+          )}
+        >
+          {rate != null
+            ? `LIVE RATE: ₦${Math.round(rate).toLocaleString()} / USDC`
+            : "LIVE RATE: —"}
+        </span>
       </div>
 
       {/* Right: wallet button + balances */}

--- a/src/hooks/useFxRate.ts
+++ b/src/hooks/useFxRate.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const INTERVAL = 30_000;
+
+export function useFxRate() {
+  const [rate, setRate] = useState<number | null>(null);
+  const [flash, setFlash] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  async function fetchRate() {
+    if (document.visibilityState === "hidden") return;
+    try {
+      const res = await fetch("/api/offramp/rate", { cache: "no-store" });
+      if (!res.ok) return;
+      const { rate: r } = await res.json();
+      if (typeof r === "number" && r > 0) {
+        setRate(r);
+        setFlash(true);
+        setTimeout(() => setFlash(false), 600);
+      }
+    } catch {
+      // silently ignore
+    }
+  }
+
+  useEffect(() => {
+    fetchRate();
+    timerRef.current = setInterval(fetchRate, INTERVAL);
+
+    function onVisibility() {
+      if (document.visibilityState === "visible") fetchRate();
+    }
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
+
+  return { rate, flash };
+}


### PR DESCRIPTION
- GET /api/offramp/rate — fetches USDC/NGN rate from Paycrest
- useFxRate hook — polls every 30s, pauses when tab hidden via visibilitychange, brief flash animation on update
- Header — FX chip shows 'LIVE RATE: ₦X,XXX / USDC' with aria-live
Closes #203 