### PR TITLE
docs: add API, contributor, deployment, and user guides (#236-#239)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,602 @@
+# Stellar-Spend API Documentation
+
+Base URL: `http://localhost:3001` (development)
+
+## Authentication
+
+All `/api/offramp/*` endpoints are **server-side only** and use environment-configured secrets. Clients call these routes directly — no client-side API key is required or exposed.
+
+The webhook endpoint (`/api/webhooks/paycrest`) verifies requests using HMAC-SHA256 via the `X-Paycrest-Signature` header.
+
+---
+
+## Rate Limiting
+
+Two endpoints enforce per-IP rate limits:
+
+| Endpoint | Limit |
+|---|---|
+| `POST /api/offramp/bridge/build-tx` | See `buildTxLimiter` config |
+| `POST /api/offramp/paycrest/order` | See `paycrestOrderLimiter` config |
+
+Rate-limited responses return `429` with a `Retry-After` header (seconds) and `X-Request-Id`.
+
+---
+
+## Error Format
+
+All error responses follow this shape:
+
+```json
+{ "error": "Human-readable message" }
+```
+
+Validation errors from `POST /api/offramp/paycrest/order` include a `details` map:
+
+```json
+{
+  "error": "Validation failed",
+  "details": {
+    "amount": "amount must be a positive number",
+    "recipient.institution": "recipient.institution is required and must be a string"
+  }
+}
+```
+
+---
+
+## Endpoints
+
+### GET /api/health
+
+Returns service health and version.
+
+**Response `200`**
+```json
+{
+  "status": "ok",
+  "timestamp": "2026-04-22T22:30:11.068Z",
+  "version": "1.0.0"
+}
+```
+
+```bash
+curl http://localhost:3001/api/health
+```
+
+---
+
+### GET /api/offramp/currencies
+
+Returns supported fiat currencies. Cached for 5 minutes.
+
+**Response `200`**
+```json
+{
+  "data": [
+    { "code": "NGN", "name": "Nigerian Naira", "symbol": "₦" },
+    { "code": "KES", "name": "Kenyan Shilling", "symbol": "KSh" }
+  ]
+}
+```
+
+**Errors**
+
+| Status | Meaning |
+|---|---|
+| `500` | Paycrest API unreachable |
+
+```bash
+curl http://localhost:3001/api/offramp/currencies
+```
+
+---
+
+### GET /api/offramp/institutions/[currency]
+
+Returns supported banks/institutions for a given fiat currency code.
+
+**Path Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `currency` | string | Fiat currency code, e.g. `NGN` |
+
+**Response `200`**
+```json
+[
+  { "code": "ACCESS", "name": "Access Bank" },
+  { "code": "GTB", "name": "Guaranty Trust Bank" }
+]
+```
+
+**Errors**
+
+| Status | Meaning |
+|---|---|
+| `400` | Unsupported or unknown currency |
+| `500` | Internal server error |
+
+```bash
+curl http://localhost:3001/api/offramp/institutions/NGN
+```
+
+---
+
+### POST /api/offramp/quote
+
+Fetches a conversion quote: Stellar USDC → fiat via Allbridge + Paycrest.
+
+**Request Body**
+
+```json
+{
+  "amount": "100",
+  "currency": "NGN",
+  "feeMethod": "USDC"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `amount` | string | ✅ | USDC amount to convert |
+| `currency` | string | ✅ | Target fiat currency code |
+| `feeMethod` | string | ✅ | `"USDC"` \| `"XLM"` \| `"stablecoin"` \| `"native"` |
+
+**Response `200`**
+```json
+{
+  "destinationAmount": "155000.00",
+  "rate": 1550.0,
+  "currency": "NGN",
+  "expiresIn": 300
+}
+```
+
+**Errors**
+
+| Status | Meaning |
+|---|---|
+| `400` | Invalid amount, missing currency, or invalid feeMethod |
+| `502` | Allbridge or Paycrest quote unavailable |
+| `500` | Unexpected server error |
+
+```bash
+curl -X POST http://localhost:3001/api/offramp/quote \
+  -H "Content-Type: application/json" \
+  -d '{"amount":"100","currency":"NGN","feeMethod":"USDC"}'
+```
+
+---
+
+### POST /api/offramp/verify-account
+
+Verifies a beneficiary bank account via Paycrest.
+
+**Request Body**
+
+```json
+{
+  "institution": "ACCESS",
+  "accountIdentifier": "0123456789"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `institution` | string | ✅ | Institution code from `/institutions/[currency]` |
+| `accountIdentifier` | string | ✅ | Account number or identifier |
+
+**Response `200`**
+```json
+{ "accountName": "John Doe" }
+```
+
+**Errors**
+
+| Status | Meaning |
+|---|---|
+| `400` | Missing fields or account not found |
+| `502` | Paycrest upstream error (5xx from Paycrest) |
+| `500` | Internal server error |
+
+```bash
+curl -X POST http://localhost:3001/api/offramp/verify-account \
+  -H "Content-Type: application/json" \
+  -d '{"institution":"ACCESS","accountIdentifier":"0123456789"}'
+```
+
+---
+
+### GET /api/offramp/bridge/gas-fee-options
+
+Returns Allbridge gas fee options for the Stellar → Base USDC bridge. Cached for 60 seconds.
+
+**Response `200`**
+```json
+{
+  "feeOptions": {
+    "native": { "int": "1000000", "float": "1.0" },
+    "stablecoin": { "int": "500000", "float": "0.5" }
+  }
+}
+```
+
+`native` = XLM fee, `stablecoin` = USDC fee.
+
+**Errors**
+
+| Status | Meaning |
+|---|---|
+| `502` | Allbridge SDK timeout or unavailable |
+| `500` | Chain details or token not found |
+
+```bash
+curl http://localhost:3001/api/offramp/bridge/gas-fee-options
+```
+
+---
+
+### POST /api/offramp/bridge/build-tx
+
+Builds an unsigned Soroban XDR transaction for bridging USDC from Stellar to Base via Allbridge. Rate-limited per IP.
+
+**Request Body**
+
+```json
+{
+  "amount": "99.5",
+  "fromAddress": "GABC...XYZ",
+  "toAddress": "0xabc...def",
+  "feePaymentMethod": "stablecoin"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `amount` | string | ✅ | USDC amount to bridge |
+| `fromAddress` | string | ✅ | Stellar (G...) sender address |
+| `toAddress` | string | ✅ | Base (0x...) recipient address |
+| `feePaymentMethod` | string | | `"stablecoin"` (default) or `"native"` |
+
+**Response `200`**
+```json
+{
+  "xdr": "AAAAAgAAAA...",
+  "sourceToken": {
+    "symbol": "USDC",
+    "decimals": 7,
+    "contract": "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75",
+    "chain": "SRB"
+  },
+  "destinationToken": {
+    "symbol": "USDC",
+    "decimals": 6,
+    "contract": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "chain": "ETH"
+  }
+}
+```
+
+**Errors**
+
+| Status | Meaning |
+|---|---|
+| `400` | Invalid amount, address, or feePaymentMethod |
+| `429` | Rate limit exceeded — check `Retry-After` header |
+| `500` | Simulation failed, insufficient balance, or chain unavailable |
+
+```bash
+curl -X POST http://localhost:3001/api/offramp/bridge/build-tx \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "99.5",
+    "fromAddress": "GABC...XYZ",
+    "toAddress": "0xabc...def",
+    "feePaymentMethod": "stablecoin"
+  }'
+```
+
+---
+
+### POST /api/offramp/bridge/submit-soroban
+
+Submits a signed Stellar XDR transaction to the Soroban RPC.
+
+**Request Body**
+
+```json
+{ "signedXdr": "AAAAAgAAAA..." }
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `signedXdr` | string | ✅ | Signed transaction XDR from the wallet |
+
+**Response `200`**
+```json
+{ "status": "PENDING", "hash": "abc123..." }
+```
+
+| `status` | Meaning |
+|---|---|
+| `PENDING` | Transaction accepted, awaiting confirmation |
+| `SUCCESS` | Transaction confirmed on-chain |
+
+**Errors**
+
+| Status | Meaning |
+|---|---|
+| `400` | Missing `signedXdr`, RPC error, or transaction rejected |
+| `500` | Soroban RPC not configured or unreachable |
+
+```bash
+curl -X POST http://localhost:3001/api/offramp/bridge/submit-soroban \
+  -H "Content-Type: application/json" \
+  -d '{"signedXdr":"AAAAAgAAAA..."}'
+```
+
+---
+
+### GET /api/offramp/bridge/tx-status/[hash]
+
+Polls the Soroban RPC for a submitted transaction's confirmation status.
+
+**Path Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `hash` | string | Transaction hash from `submit-soroban` |
+
+**Response `200`**
+```json
+{ "status": "SUCCESS", "hash": "abc123..." }
+```
+
+| `status` | Meaning |
+|---|---|
+| `SUCCESS` | Transaction confirmed |
+| `FAILED` | Transaction failed on-chain |
+| `NOT_FOUND` | Not yet indexed or invalid hash |
+
+**Errors**
+
+| Status | Meaning |
+|---|---|
+| `400` | RPC returned an error |
+| `500` | Soroban RPC not configured or unreachable |
+
+```bash
+curl http://localhost:3001/api/offramp/bridge/tx-status/abc123...
+```
+
+---
+
+### GET /api/offramp/bridge/status/[txHash]
+
+Polls Allbridge for the cross-chain bridge transfer status.
+
+**Path Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `txHash` | string | Stellar transaction hash |
+
+**Response `200`**
+```json
+{
+  "data": {
+    "status": "completed",
+    "txHash": "abc123...",
+    "receiveAmount": "99.0"
+  }
+}
+```
+
+| `status` | Meaning |
+|---|---|
+| `pending` | Bridge not yet picked up the transfer |
+| `processing` | Transfer in progress |
+| `completed` | USDC arrived on Base |
+| `failed` | Bridge transfer failed |
+| `expired` | Transfer expired |
+
+**Errors**
+
+| Status | Meaning |
+|---|---|
+| `500` | Allbridge SDK error |
+
+```bash
+curl http://localhost:3001/api/offramp/bridge/status/abc123...
+```
+
+---
+
+### POST /api/offramp/paycrest/order
+
+Creates a Paycrest fiat payout order. Rate-limited per IP.
+
+**Request Body**
+
+```json
+{
+  "amount": 99.0,
+  "rate": 1550.0,
+  "token": "USDC",
+  "network": "base",
+  "reference": "ref-unique-123",
+  "returnAddress": "0xabc...def",
+  "recipient": {
+    "institution": "ACCESS",
+    "accountIdentifier": "0123456789",
+    "accountName": "John Doe",
+    "currency": "NGN"
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `amount` | number | ✅ | USDC amount (positive) |
+| `rate` | number | ✅ | FX rate from `/quote` (positive) |
+| `token` | string | ✅ | Token symbol, e.g. `"USDC"` |
+| `network` | string | ✅ | Chain name, e.g. `"base"` |
+| `reference` | string | ✅ | Unique reference string |
+| `returnAddress` | string | ✅ | Base address for refunds |
+| `recipient.institution` | string | ✅ | Bank institution code |
+| `recipient.accountIdentifier` | string | ✅ | Account number |
+| `recipient.accountName` | string | ✅ | Verified account name |
+| `recipient.currency` | string | ✅ | Fiat currency code |
+
+**Response `200`**
+```json
+{
+  "data": {
+    "id": "order-uuid",
+    "receiveAddress": "0xpaycrest...address"
+  }
+}
+```
+
+**Errors**
+
+| Status | Meaning |
+|---|---|
+| `400` | Validation failed — see `details` map |
+| `429` | Rate limit exceeded — check `Retry-After` header |
+| `4xx` | Paycrest rejected the order |
+| `500` | Internal server error |
+
+```bash
+curl -X POST http://localhost:3001/api/offramp/paycrest/order \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": 99.0,
+    "rate": 1550.0,
+    "token": "USDC",
+    "network": "base",
+    "reference": "ref-unique-123",
+    "returnAddress": "0xabc...def",
+    "recipient": {
+      "institution": "ACCESS",
+      "accountIdentifier": "0123456789",
+      "accountName": "John Doe",
+      "currency": "NGN"
+    }
+  }'
+```
+
+---
+
+### GET /api/offramp/paycrest/order/[orderId]
+
+Fetches the status of a Paycrest payout order.
+
+**Path Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `orderId` | string | Order ID from `POST /api/offramp/paycrest/order` |
+
+**Response `200`**
+```json
+{
+  "data": {
+    "id": "order-uuid",
+    "status": "pending"
+  }
+}
+```
+
+**Errors**
+
+| Status | Meaning |
+|---|---|
+| `400` | Missing orderId |
+| `404` | Order not found |
+| `500` | Internal server error |
+
+```bash
+curl http://localhost:3001/api/offramp/paycrest/order/order-uuid
+```
+
+---
+
+### GET /api/offramp/status/[orderId]
+
+Polls Paycrest order status using Bearer token auth (alternative to the adapter-based route above).
+
+**Path Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `orderId` | string | Paycrest order ID |
+
+**Response `200`**
+```json
+{ "status": "pending", "id": "order-uuid" }
+```
+
+**Errors**
+
+| Status | Meaning |
+|---|---|
+| `4xx/5xx` | Forwarded from Paycrest |
+| `500` | Internal server error |
+
+```bash
+curl http://localhost:3001/api/offramp/status/order-uuid
+```
+
+---
+
+### POST /api/webhooks/paycrest
+
+Receives Paycrest event webhooks. Verifies the `X-Paycrest-Signature` HMAC-SHA256 header before processing.
+
+**Headers**
+
+| Header | Required | Description |
+|---|---|---|
+| `X-Paycrest-Signature` | ✅ | HMAC-SHA256 hex digest of the raw request body, keyed with `PAYCREST_WEBHOOK_SECRET` |
+
+**Request Body** (example)
+```json
+{
+  "event": "payment_order.settled",
+  "data": { "id": "order-uuid" }
+}
+```
+
+**Response `200`**
+```json
+{ "received": true }
+```
+
+**Errors**
+
+| Status | Meaning |
+|---|---|
+| `401` | Invalid or missing signature |
+| `400` | Malformed JSON payload |
+
+---
+
+## Typical Off-Ramp Flow
+
+```
+1. GET  /api/offramp/currencies              → pick fiat currency
+2. GET  /api/offramp/institutions/[currency] → pick bank
+3. POST /api/offramp/verify-account          → confirm account name
+4. POST /api/offramp/quote                   → get FX rate + destination amount
+5. GET  /api/offramp/bridge/gas-fee-options  → pick fee method
+6. POST /api/offramp/bridge/build-tx         → get unsigned XDR
+   (wallet signs XDR)
+7. POST /api/offramp/bridge/submit-soroban   → submit signed XDR → get txHash
+8. GET  /api/offramp/bridge/tx-status/[hash] → poll until SUCCESS
+9. POST /api/offramp/paycrest/order          → create payout order → get orderId + receiveAddress
+   (bridge delivers USDC to receiveAddress)
+10. GET /api/offramp/bridge/status/[txHash]  → poll until completed
+11. GET /api/offramp/paycrest/order/[id]     → poll until settled
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,291 @@
+# Contributing to Stellar-Spend
+
+Thanks for your interest in contributing. This guide covers everything you need to get oriented, write code that fits the project, and get your changes merged.
+
+---
+
+## Table of Contents
+
+1. [Project Architecture](#project-architecture)
+2. [Project Structure](#project-structure)
+3. [Local Setup](#local-setup)
+4. [Coding Standards](#coding-standards)
+5. [Testing Requirements](#testing-requirements)
+6. [Git Workflow & PR Guidelines](#git-workflow--pr-guidelines)
+7. [Troubleshooting](#troubleshooting)
+
+---
+
+## Project Architecture
+
+Stellar-Spend is a **Next.js 15 App Router** application. There is no separate backend — all server logic lives in Next.js API route handlers under `src/app/api/`.
+
+The off-ramp flow has three stages:
+
+```
+Stellar wallet  →  Allbridge bridge  →  Base chain  →  Paycrest payout  →  Bank account
+     (XDR)           (Soroban tx)        (USDC)          (fiat order)
+```
+
+Key architectural decisions:
+
+- **No database.** Transaction history is stored in browser `localStorage` (key: `stellar_spend_transactions`, max 50 records).
+- **Secrets stay server-side.** `PAYCREST_API_KEY` and `BASE_PRIVATE_KEY` are validated at startup and must never use the `NEXT_PUBLIC_` prefix. The app throws a clear error if they are misconfigured.
+- **Allbridge SDK is dynamically imported** in API routes to avoid bundling it into the client.
+- **Adapters pattern.** External services (Allbridge, Paycrest, Soroban) are wrapped in adapter classes under `src/lib/offramp/adapters/` so they can be mocked in tests.
+
+---
+
+## Project Structure
+
+```
+src/
+├── app/
+│   ├── api/
+│   │   ├── health/               # GET /api/health
+│   │   ├── offramp/
+│   │   │   ├── bridge/           # build-tx, submit-soroban, tx-status, status, gas-fee-options
+│   │   │   ├── currencies/       # GET supported fiat currencies
+│   │   │   ├── institutions/     # GET banks by currency
+│   │   │   ├── paycrest/order/   # POST create order, GET order status
+│   │   │   ├── quote/            # POST get FX quote
+│   │   │   ├── status/           # GET payout order status (legacy)
+│   │   │   └── verify-account/   # POST verify bank account
+│   │   └── webhooks/paycrest/    # POST Paycrest event webhook
+│   ├── history/                  # Transaction history page
+│   └── page.tsx                  # Main off-ramp UI
+├── components/
+│   ├── ui/                       # Primitive UI components (InputField, SelectField, etc.)
+│   ├── FormCard.tsx              # Main form (amount, beneficiary, fee method)
+│   ├── StellarSpendDashboard.tsx # Top-level page orchestrator
+│   └── TransactionProgressModal.tsx  # Step-by-step progress overlay
+├── hooks/                        # React hooks (wallet, polling, theme)
+├── lib/
+│   ├── env.ts                    # Env validation — throws at startup if misconfigured
+│   ├── error-handler.ts          # Centralised NextResponse error helpers
+│   ├── transaction-storage.ts    # localStorage read/write
+│   ├── stellar/wallet-adapter.ts # Freighter + Lobstr wallet abstraction
+│   └── offramp/
+│       ├── adapters/             # Allbridge, Paycrest, Soroban adapters
+│       ├── types/                # Shared TypeScript types (TradeState, BridgeStatus, etc.)
+│       └── utils/                # validation, polling, timeout, rate-limiter, logger
+├── contexts/                     # React contexts (ToastContext)
+├── types/                        # Global type declarations
+└── test/                         # Unit/integration tests + test helpers
+```
+
+---
+
+## Local Setup
+
+### Prerequisites
+
+- Node.js 18 or 20 (matches CI matrix)
+- npm
+
+### Steps
+
+```bash
+# 1. Install dependencies
+npm install
+
+# 2. Create your local env file
+cp .env.example .env.local
+
+# 3. Fill in .env.local — see inline comments in .env.example
+#    Required server vars: PAYCREST_API_KEY, PAYCREST_WEBHOOK_SECRET,
+#                          BASE_PRIVATE_KEY, BASE_RETURN_ADDRESS, BASE_RPC_URL,
+#                          STELLAR_SOROBAN_RPC_URL, STELLAR_HORIZON_URL
+#    Required public vars: NEXT_PUBLIC_STELLAR_SOROBAN_RPC_URL,
+#                          NEXT_PUBLIC_BASE_RETURN_ADDRESS,
+#                          NEXT_PUBLIC_STELLAR_USDC_ISSUER
+
+# 4. Start the dev server
+npm run dev
+# → http://localhost:3001
+```
+
+The app validates all required env vars at startup and throws a descriptive error if any are missing or if a secret is accidentally exposed via `NEXT_PUBLIC_`.
+
+---
+
+## Coding Standards
+
+### Language & Tooling
+
+- **TypeScript** everywhere — no `any` unless wrapping an untyped third-party SDK (add a comment explaining why).
+- **ESLint** with zero warnings: `npm run lint`. CI fails on any warning.
+- **Tailwind CSS v4** for styling. No inline `style` props unless unavoidable.
+- Use the `cn()` helper from `src/lib/cn.ts` for conditional class merging.
+
+### File Conventions
+
+- API route files are named `route.ts` and export named HTTP method functions (`GET`, `POST`).
+- One component per file. File name matches the exported component name.
+- Co-locate tests with the code they test when it's a unit test for a single module (e.g., `validation.test.ts` next to `validation.ts`). Integration/component tests go in `src/test/`.
+
+### Error Handling
+
+- API routes return errors via `NextResponse.json({ error: "..." }, { status: N })`.
+- Use `ErrorHandler` from `src/lib/error-handler.ts` for standard error shapes.
+- Never swallow errors silently — log with `console.error` before returning a response.
+- Distinguish upstream failures (502) from client mistakes (400) from server bugs (500).
+
+### Environment Variables
+
+- Server-only secrets: no `NEXT_PUBLIC_` prefix. Ever.
+- Access env vars through the validated `env` object from `src/lib/env.ts`, not directly via `process.env`.
+- If you add a new required env var, add it to `requiredServerEnvKeys` or `requiredPublicEnvKeys` in `env.ts` and to `.env.example` with an inline comment.
+
+### Rate Limiting & Logging
+
+- Endpoints that trigger expensive external calls (Allbridge SDK, Paycrest order creation) use the rate limiter from `src/lib/offramp/utils/rate-limiter.ts`.
+- Use `generateRequestId` + `createRequestLogger` for structured logging in rate-limited routes. Include `X-Request-Id` in responses.
+
+---
+
+## Testing Requirements
+
+### Running Tests
+
+```bash
+npm test              # run all unit tests once (Vitest)
+npm run test:watch    # watch mode
+npm run test:e2e      # Playwright end-to-end (requires dev server)
+```
+
+### Test Framework
+
+- **Unit/integration**: [Vitest](https://vitest.dev/) + [Testing Library](https://testing-library.com/) + jsdom
+- **E2E**: [Playwright](https://playwright.dev/) targeting `http://localhost:3001`
+- Setup file: `src/test/setup.ts` (imports `@testing-library/jest-dom`)
+
+### What to Test
+
+| Change type | Required tests |
+|---|---|
+| New API route | Unit test for validation, happy path, and error cases |
+| New utility function | Unit test covering edge cases |
+| New React component | Render test + key interaction test |
+| Bug fix | Regression test that fails before the fix |
+
+### Test Helpers
+
+`src/test/test-helpers.ts` provides:
+
+- `createTestTransaction(overrides?)` — factory for `Transaction` objects
+- `createValidStellarAddress()` — generates a valid G-key format address
+- `createValidBaseAddress()` — generates a valid 0x address
+- `createLocalStorageMock()` — in-memory localStorage substitute
+
+Use these instead of hardcoding test data.
+
+### Mocking External Services
+
+Adapters in `src/lib/offramp/adapters/` are the seam for mocking. Mock the adapter class, not the underlying `fetch` calls, unless you are specifically testing the adapter itself.
+
+### CI Requirements
+
+CI runs on Node 18 and 20. A PR cannot merge if:
+
+- `npm run lint` exits non-zero
+- `npm run build` fails
+- `npm test` has any failing test
+- The `.next` build output exceeds 150 MB
+
+---
+
+## Git Workflow & PR Guidelines
+
+### Branching
+
+```
+main          ← protected, always deployable
+feat/<topic>  ← new features
+fix/<topic>   ← bug fixes
+docs/<topic>  ← documentation only
+chore/<topic> ← tooling, deps, config
+```
+
+Branch off `main`. Keep branches focused on a single concern.
+
+### Commits
+
+Write commits in the imperative mood, present tense:
+
+```
+# Good
+feat: add gas fee options endpoint
+fix: handle 404 from Allbridge status poll
+docs: add API documentation
+
+# Avoid
+Added gas fee options
+Fixed a bug
+```
+
+Reference the issue number when relevant: `fix: handle empty currency list (#42)`.
+
+### Pull Requests
+
+1. **Push to a new branch** — never directly to `main`.
+2. Open a PR against `main`.
+3. Keep the title under 70 characters.
+4. PR description should cover:
+   - What changed and why
+   - How it was tested
+   - Any follow-up work or known limitations
+5. All CI checks must pass before merging.
+6. At least one review approval is required.
+
+### Before Opening a PR
+
+```bash
+npm run lint    # zero warnings
+npm test        # all tests pass
+npm run build   # clean build
+```
+
+---
+
+## Troubleshooting
+
+### App fails to start with env error
+
+```
+Error: Invalid environment configuration for Stellar-Spend.
+Missing required server env vars: PAYCREST_API_KEY, ...
+```
+
+You have missing or placeholder values in `.env.local`. Copy `.env.example` and fill in real values. The error message lists exactly which keys are missing.
+
+### `NEXT_PUBLIC_` secret exposure error
+
+```
+Remove secret values from public env vars: NEXT_PUBLIC_PAYCREST_API_KEY
+```
+
+You have set a secret with the `NEXT_PUBLIC_` prefix. Rename it to remove the prefix and access it only in server-side code.
+
+### Allbridge SDK errors in tests
+
+The Allbridge SDK is dynamically imported and makes real network calls. Tests that exercise routes using the SDK should mock the `@allbridge/bridge-core-sdk` module or the `AllbridgeAdapter` class directly.
+
+### `Bridge quote unavailable` / `FX rate unavailable` in development
+
+These 502 errors mean the Allbridge or Paycrest upstream is unreachable. Check:
+- `BASE_RPC_URL` and `STELLAR_SOROBAN_RPC_URL` are valid and reachable
+- Your network allows outbound HTTPS to `api.paycrest.io`
+- Allbridge SDK `nodeRpcUrlsDefault` endpoints are up
+
+### Vitest can't find `@/` imports
+
+The `@` alias is configured in `vitest.config.ts` to resolve to `src/`. If you see module-not-found errors, confirm you haven't moved files outside `src/` and that the import path starts with `@/`.
+
+### Playwright tests fail locally
+
+E2E tests expect the dev server at `http://localhost:3001`. Run `npm run dev` in a separate terminal before `npm run test:e2e`, or let Playwright start it automatically (it will if no server is already listening).
+
+### Bundle size CI check fails
+
+Run `npm run build:analyze` to open the interactive treemap and identify what grew. The limit is 150 MB for the `.next` output directory. Large expected dependencies are `@stellar/stellar-sdk`, `@allbridge/bridge-core-sdk`, and `viem`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,246 @@
+# Deployment Guide
+
+This guide covers deploying Stellar-Spend to production on Vercel, including environment configuration, DNS setup, monitoring, and rollback procedures.
+
+---
+
+## Table of Contents
+
+1. [Prerequisites](#prerequisites)
+2. [Environment Variables](#environment-variables)
+3. [Vercel Deployment](#vercel-deployment)
+4. [DNS and Domain Setup](#dns-and-domain-setup)
+5. [Monitoring and Logging](#monitoring-and-logging)
+6. [Rollback Procedures](#rollback-procedures)
+
+---
+
+## Prerequisites
+
+- A [Vercel](https://vercel.com) account with the project imported
+- A [Paycrest](https://paycrest.io) account with an API key and webhook secret
+- A dedicated Base wallet (private key + public address) for payout execution
+- A Base RPC provider URL (e.g. Alchemy, QuickNode, or `https://mainnet.base.org`)
+- A Stellar Soroban RPC endpoint (e.g. `https://soroban-rpc.mainnet.stellar.gateway.fm`)
+- (Optional) A [Sentry](https://sentry.io) project for error monitoring
+
+---
+
+## Environment Variables
+
+All variables must be set in Vercel's **Environment Variables** settings (Settings → Environment Variables). Set them for the **Production** environment at minimum; mirror to Preview/Development as needed.
+
+### Required — Server Only
+
+These must **never** use the `NEXT_PUBLIC_` prefix. The app throws a startup error if they are missing or accidentally exposed.
+
+| Variable | Description |
+|---|---|
+| `PAYCREST_API_KEY` | Paycrest API key from the Paycrest dashboard |
+| `PAYCREST_WEBHOOK_SECRET` | Webhook signing secret from Paycrest webhook settings |
+| `BASE_PRIVATE_KEY` | Private key of the Base wallet that signs payout transactions |
+| `BASE_RETURN_ADDRESS` | Public Base address for refunds/treasury routing |
+| `BASE_RPC_URL` | Base mainnet RPC URL |
+| `STELLAR_SOROBAN_RPC_URL` | Soroban RPC endpoint for server-side tx building |
+| `STELLAR_HORIZON_URL` | Horizon endpoint for account/trustline lookups (use `https://horizon.stellar.org`) |
+
+### Required — Public (Browser-Safe)
+
+| Variable | Description |
+|---|---|
+| `NEXT_PUBLIC_STELLAR_SOROBAN_RPC_URL` | Soroban RPC endpoint exposed to the browser |
+| `NEXT_PUBLIC_BASE_RETURN_ADDRESS` | Base return address shown to the browser |
+| `NEXT_PUBLIC_STELLAR_USDC_ISSUER` | Stellar USDC issuer account (from Circle/Stellar docs) |
+
+### Optional
+
+| Variable | Description |
+|---|---|
+| `SENTRY_DSN` | Sentry DSN for server-side error tracking |
+| `NEXT_PUBLIC_SENTRY_DSN` | Sentry DSN for browser-side error tracking |
+| `SENTRY_ORG` | Sentry org slug (required for source map uploads) |
+| `SENTRY_PROJECT` | Sentry project slug (required for source map uploads) |
+| `SENTRY_AUTH_TOKEN` | Sentry auth token for source map uploads during CI builds |
+| `ALLOWED_ORIGINS` | Comma-separated list of allowed CORS origins (e.g. `https://your-app.vercel.app,https://www.your-domain.com`). When empty, only localhost origins are allowed — always set this in production. |
+| `ANALYZE` | Set to `true` to generate a bundle analysis report during build |
+
+---
+
+## Vercel Deployment
+
+### First Deployment (Manual)
+
+1. Install the Vercel CLI:
+   ```bash
+   npm i -g vercel
+   ```
+
+2. Link the project:
+   ```bash
+   vercel link
+   ```
+   Follow the prompts to connect to your Vercel org and project. This creates `.vercel/project.json` with `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID`.
+
+3. Set all environment variables in the Vercel dashboard (Settings → Environment Variables) before deploying.
+
+4. Deploy to production:
+   ```bash
+   vercel --prod
+   ```
+
+### Automated Deployment via GitHub Actions
+
+The repository includes `.github/workflows/deploy.yml`. It triggers on every push to `main`, runs CI (lint + build + tests), then deploys to Vercel if CI passes.
+
+Required GitHub Actions secrets (Settings → Secrets and variables → Actions):
+
+| Secret | Where to get it |
+|---|---|
+| `VERCEL_TOKEN` | Vercel dashboard → Account Settings → Tokens |
+| `VERCEL_ORG_ID` | `.vercel/project.json` after `vercel link` |
+| `VERCEL_PROJECT_ID` | `.vercel/project.json` after `vercel link` |
+| `SENTRY_AUTH_TOKEN` | Sentry → Settings → Auth Tokens |
+
+The deploy job runs in the `production` GitHub environment. You can add required reviewers to that environment in Settings → Environments for an approval gate before production deploys.
+
+### Build Configuration
+
+The app uses `output: "standalone"` in `next.config.ts`, which Vercel handles automatically. No custom build command is needed — Vercel detects Next.js and runs `next build`.
+
+The build fails if the `.next` output exceeds **150 MB**. Run `npm run build:analyze` locally to investigate bundle size before pushing.
+
+---
+
+## DNS and Domain Setup
+
+### Adding a Custom Domain in Vercel
+
+1. Go to your Vercel project → Settings → Domains.
+2. Enter your domain (e.g. `app.your-domain.com`) and click Add.
+3. Vercel will show the required DNS records.
+
+### DNS Records
+
+| Type | Name | Value |
+|---|---|---|
+| `A` | `@` (apex) | `76.76.21.21` (Vercel's IP) |
+| `CNAME` | `www` | `cname.vercel-dns.com` |
+
+For a subdomain (e.g. `app.your-domain.com`):
+
+| Type | Name | Value |
+|---|---|---|
+| `CNAME` | `app` | `cname.vercel-dns.com` |
+
+DNS propagation typically takes a few minutes to a few hours. Vercel provisions a TLS certificate automatically via Let's Encrypt once DNS resolves.
+
+### Update CORS After Domain Change
+
+Once your domain is live, set `ALLOWED_ORIGINS` in Vercel to your production origin(s):
+
+```
+ALLOWED_ORIGINS=https://app.your-domain.com,https://www.your-domain.com
+```
+
+Without this, the API will reject browser requests from your custom domain.
+
+### Update Paycrest Webhook URL
+
+In the Paycrest dashboard, update the webhook endpoint to:
+
+```
+https://app.your-domain.com/api/webhooks/paycrest
+```
+
+---
+
+## Monitoring and Logging
+
+### Sentry (Error Tracking)
+
+Sentry is pre-configured in three files:
+
+- `sentry.server.config.ts` — server-side (API routes, SSR)
+- `sentry.client.config.ts` — browser
+- `sentry.edge.config.ts` — edge runtime
+
+Both use `tracesSampleRate: 0.1` (10% of transactions traced). Adjust this in the config files if you need more or less trace coverage.
+
+To enable Sentry:
+1. Create a project at [sentry.io](https://sentry.io).
+2. Set `SENTRY_DSN` and `NEXT_PUBLIC_SENTRY_DSN` in Vercel.
+3. Set `SENTRY_ORG`, `SENTRY_PROJECT`, and `SENTRY_AUTH_TOKEN` for source map uploads.
+
+Source maps are uploaded automatically during CI builds (`hideSourceMaps: true` keeps them off the CDN).
+
+### Vercel Logs
+
+- **Runtime logs**: Vercel dashboard → your project → Logs tab. Filter by function path (e.g. `/api/offramp/bridge/build-tx`).
+- **Build logs**: Vercel dashboard → Deployments → select a deployment → Build Logs.
+
+Structured log lines from API routes include a `requestId` field (set as `X-Request-Id` in responses) which you can use to correlate logs across a single request.
+
+### Health Check
+
+```bash
+curl https://app.your-domain.com/api/health
+# {"status":"ok","timestamp":"...","version":"0.1.0"}
+```
+
+Use this endpoint for uptime monitoring (e.g. UptimeRobot, Better Uptime). A non-200 response or missing `"status":"ok"` indicates the deployment is unhealthy.
+
+---
+
+## Rollback Procedures
+
+### Instant Rollback via Vercel Dashboard
+
+1. Go to your Vercel project → Deployments.
+2. Find the last known-good deployment.
+3. Click the `...` menu → **Promote to Production**.
+
+This is instant — no rebuild required. The previous deployment's build artifacts are already cached.
+
+### Rollback via CLI
+
+```bash
+# List recent deployments
+vercel ls --prod
+
+# Promote a specific deployment URL to production
+vercel promote <deployment-url>
+```
+
+### Rollback via Git
+
+If you need to revert the code as well:
+
+```bash
+# Revert the bad commit and push — triggers the deploy workflow automatically
+git revert <bad-commit-sha>
+git push origin main
+```
+
+Avoid `git reset --hard` + force push on `main` — it breaks the deployment history and other contributors' branches.
+
+### Environment Variable Rollback
+
+If a bad env var value caused the incident:
+
+1. Go to Vercel → Settings → Environment Variables.
+2. Edit the affected variable.
+3. Trigger a redeploy: Vercel dashboard → Deployments → `...` → **Redeploy** on the last good deployment (this picks up the updated env vars with the old code).
+
+### Verifying a Rollback
+
+After promoting or redeploying:
+
+```bash
+# Check health
+curl https://app.your-domain.com/api/health
+
+# Confirm the deployed version matches expectations
+# (version field comes from package.json)
+```
+
+Check Sentry for a drop in error rate within a few minutes of the rollback completing.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,255 @@
+# Stellar-Spend User Guide
+
+Convert your Stellar stablecoins (USDC) to fiat currency and receive funds directly in your bank account.
+
+> **Note for maintainers:** Sections marked `[SCREENSHOT]` are placeholders. Replace them with actual screenshots once the UI is stable.
+
+---
+
+## Table of Contents
+
+1. [What You Need](#what-you-need)
+2. [Connecting Your Wallet](#connecting-your-wallet)
+3. [Making a Conversion](#making-a-conversion)
+4. [Transaction Status Tracking](#transaction-status-tracking)
+5. [Transaction History](#transaction-history)
+6. [FAQ](#faq)
+7. [Troubleshooting](#troubleshooting)
+
+---
+
+## What You Need
+
+Before you start:
+
+- A **Freighter** or **Lobstr** Stellar wallet browser extension, installed and set up
+- **USDC on Stellar** (the token you'll be converting)
+- A small amount of **XLM** in your wallet (required for Stellar network fees — minimum ~3 XLM reserve + ~2.5 XLM for gas, unless you pay fees in USDC)
+- Your **bank account details**: account number and the name of your bank
+
+---
+
+## Connecting Your Wallet
+
+### Step 1 — Open the app
+
+Navigate to the app URL. You'll see the Offramp Dashboard with three progress steps at the bottom. Step **01 — CONNECT WALLET** will be highlighted.
+
+`[SCREENSHOT: Dashboard on first load, step 01 highlighted, Connect Wallet button visible in the header]`
+
+### Step 2 — Click "Connect Wallet"
+
+Click the **Connect Wallet** button in the top-right header.
+
+The app auto-detects your installed wallet:
+- If **Freighter** is installed, it connects automatically.
+- If only **Lobstr** is installed, it connects to Lobstr.
+- If both are installed, Freighter takes priority.
+
+Your wallet extension will open and ask you to approve the connection.
+
+`[SCREENSHOT: Freighter extension popup requesting connection approval]`
+
+### Step 3 — Approve the connection
+
+Click **Connect** (or **Approve**) in your wallet extension.
+
+Once connected, the header updates to show:
+- Your wallet address (truncated, e.g. `GABC...XYZ`)
+- Your **USDC** balance
+- Your **XLM** balance
+- Which wallet is connected (Freighter or Lobstr)
+
+`[SCREENSHOT: Header showing connected wallet address, USDC and XLM balances]`
+
+### Disconnecting
+
+Click your wallet address in the header, then click **Disconnect**. This clears your session and local transaction history from the browser.
+
+---
+
+## Making a Conversion
+
+### Step 1 — Enter the amount
+
+In the form on the left, enter the amount of **USDC** you want to convert.
+
+As you type, the app fetches a live quote and shows the estimated fiat amount you'll receive in the right panel.
+
+`[SCREENSHOT: Form with amount entered, right panel showing estimated payout amount and exchange rate]`
+
+> The quote is valid for **5 minutes**. If it expires before you submit, the form will prompt you to refresh it.
+
+### Step 2 — Select your currency and bank
+
+1. Choose your **fiat currency** from the dropdown (e.g. NGN, KES).
+2. Select your **bank** from the list that appears.
+3. Enter your **account number**.
+4. Click **Verify Account** — the app will look up and display your account name for confirmation.
+
+`[SCREENSHOT: Form with currency selected, bank selected, account number entered, verified account name shown]`
+
+### Step 3 — Choose your fee payment method
+
+Select how you want to pay the Allbridge bridge fee:
+
+| Option | What it means |
+|---|---|
+| **USDC** (recommended) | Fee is deducted from your USDC amount. No extra XLM needed beyond the minimum reserve. |
+| **XLM** | Fee is paid in XLM. Requires at least ~5.5 XLM in your wallet (3 XLM reserve + ~2.5 XLM gas). |
+
+`[SCREENSHOT: Fee method toggle showing USDC and XLM options]`
+
+### Step 4 — Review and confirm
+
+Check the right panel summary:
+- Amount you're sending (USDC)
+- Exchange rate
+- Estimated fiat amount you'll receive
+- Estimated completion time
+
+When everything looks correct, click **Send**.
+
+`[SCREENSHOT: Right panel showing full quote summary before submission]`
+
+### Step 5 — Sign the transaction
+
+A progress modal appears. The app builds the bridge transaction and your wallet extension opens asking you to **sign** it.
+
+`[SCREENSHOT: Progress modal at "Awaiting Wallet Signature" step, wallet extension open in background]`
+
+Review the transaction details in your wallet and click **Sign** (or **Approve**).
+
+> **Important:** Never sign a transaction you didn't initiate. The app will only ask you to sign once per conversion.
+
+### Step 6 — Wait for completion
+
+After signing, the modal tracks progress through these steps automatically:
+
+| Step | What's happening |
+|---|---|
+| Submitting to Network | Your signed transaction is sent to the Stellar network |
+| Processing On-Chain | Allbridge picks up the transfer and moves USDC to Base |
+| Settling Fiat Payout | Paycrest processes the bank transfer |
+| Transaction Complete ✓ | Funds are on their way to your bank account |
+
+`[SCREENSHOT: Progress modal showing "Processing On-Chain" step with completed steps above it]`
+
+`[SCREENSHOT: Progress modal showing "Transaction Complete" success state with green checkmark]`
+
+The full process typically takes **5–15 minutes** depending on network conditions.
+
+Click **Dismiss** when done. The form resets and your balances refresh automatically.
+
+---
+
+## Transaction Status Tracking
+
+### Progress Modal
+
+While a conversion is in progress, the modal stays open and updates in real time. You can see exactly which step is active and which are complete.
+
+If something goes wrong, the modal switches to an **error state** showing a red icon and a description of what failed.
+
+`[SCREENSHOT: Progress modal in error state with red X icon and error message]`
+
+Click **Dismiss** to close the error modal. Your transaction is saved in history with a `failed` status.
+
+### Stellar Explorer
+
+On a successful transaction, the modal shows a link to view your transaction on [Stellar Expert](https://stellar.expert/explorer/public). Click **View transaction on Stellar Explorer →** to see the on-chain details.
+
+`[SCREENSHOT: Success modal with transaction hash and Stellar Explorer link]`
+
+---
+
+## Transaction History
+
+The **Recent Offramps** table below the form shows your last conversions for the connected wallet.
+
+`[SCREENSHOT: Recent Offramps table showing a few completed and pending transactions]`
+
+Each row shows:
+- Date and time
+- Amount sent (USDC)
+- Currency received
+- Status: `pending`, `completed`, or `failed`
+
+History is stored locally in your browser. It is scoped to your wallet address and holds up to 50 records. Disconnecting your wallet clears the history from the current session (the data remains in `localStorage` and reloads when you reconnect).
+
+To view full history, click **View All** (or navigate to `/history`).
+
+---
+
+## FAQ
+
+**Which wallets are supported?**
+Freighter and Lobstr. Freighter is auto-detected first. If you have both installed, Freighter is used.
+
+**Which tokens can I convert?**
+Currently USDC on Stellar. The bridge routes USDC from Stellar → Base before the fiat payout.
+
+**Which fiat currencies are supported?**
+The currency list is fetched live from Paycrest. Available currencies depend on your region. Select your currency in the form to see what's available.
+
+**How long does a conversion take?**
+Typically 5–15 minutes. The Allbridge bridge step (Stellar → Base) usually takes 3–10 minutes. The Paycrest bank transfer follows immediately after.
+
+**What are the fees?**
+- **Bridge fee**: paid in USDC or XLM (your choice). The exact amount is shown in the fee selector before you confirm.
+- **Payout fee**: included in the exchange rate shown in the quote. There are no hidden fees.
+
+**Is there a minimum or maximum amount?**
+Minimums and maximums are enforced by Allbridge and Paycrest. If your amount is outside the accepted range, you'll see an error when the quote is fetched.
+
+**What happens if the transaction fails mid-way?**
+- If the Stellar transaction fails before submission: your wallet is not debited.
+- If the bridge fails after submission: Allbridge will return funds to your Stellar address (this can take up to 24 hours).
+- If the Paycrest payout fails: the order status will show `refunded` or `expired` and funds are returned via the configured return address.
+
+**Is my private key ever sent to the server?**
+No. Your private key never leaves your wallet extension. The app only asks your wallet to sign a transaction — the signing happens locally in the extension.
+
+**Why does the app need my account name?**
+Paycrest requires a verified account name to process the bank transfer. The app looks it up automatically when you enter your account number — you don't need to type it manually.
+
+---
+
+## Troubleshooting
+
+### "Connect Wallet" button does nothing
+
+Your wallet extension is not installed or not detected. Install [Freighter](https://www.freighter.app/) or [Lobstr](https://lobstr.co/), refresh the page, and try again.
+
+### "Insufficient USDC balance"
+
+Your wallet has less USDC than the amount you entered. Check your balance in the header and enter a lower amount.
+
+### "Insufficient XLM for gas"
+
+You selected XLM as the fee method but don't have enough XLM. You need at least ~5.5 XLM (3 XLM minimum reserve + ~2.5 XLM for gas). Either:
+- Add more XLM to your wallet, or
+- Switch the fee method to **USDC**
+
+### "Bridge quote unavailable" or "FX rate unavailable"
+
+The Allbridge or Paycrest service is temporarily unreachable. Wait a minute and try refreshing the quote. If the issue persists, check the [Allbridge status page](https://allbridge.io) or [Paycrest status](https://paycrest.io).
+
+### Transaction stuck on "Processing On-Chain"
+
+The Allbridge bridge can take up to 10 minutes under normal conditions. If it has been more than 20 minutes:
+1. Copy your Stellar transaction hash from the success/history screen.
+2. Check the transfer status at [Allbridge Explorer](https://core.allbridge.io/explorer).
+3. If the bridge shows the transfer as failed, Allbridge will automatically refund your Stellar address.
+
+### Transaction stuck on "Settling Fiat Payout"
+
+Bank transfers can occasionally take longer due to processing windows. If the status has not changed after 30 minutes, contact Paycrest support with your order ID (visible in transaction history).
+
+### The page shows an error on load
+
+The app validates its configuration at startup. If you see a startup error, the deployment is misconfigured — contact the platform operator. This is not something you can fix as a user.
+
+### My transaction history is empty after reconnecting
+
+Transaction history is stored in your browser's `localStorage`. If you cleared your browser data or are using a different browser/device, the history will not be available. The funds are not affected — only the local display record is missing.


### PR DESCRIPTION
Add comprehensive documentation (closes #236, #237, #238, #239)

Adds four new docs under docs/:

api.md — Documents all 13 API endpoints with request/response schemas, field tables, cURL examples, error codes, and a full off-ramp flow sequence.

contributing.md — Contributor guide covering project architecture, directory structure, local setup, coding standards (TypeScript, ESLint, env var rules, error
handling), testing requirements (Vitest + Playwright, what to test per change type, mocking strategy), git workflow, and troubleshooting.

deployment.md — Production deployment guide for Vercel: all environment variables (server-only vs public, with security notes), first-deploy and CI/CD setup, 
DNS records, CORS and webhook URL post-domain steps, Sentry monitoring, and four rollback paths.

user-guide.md — End-user guide with step-by-step wallet connection, conversion walkthrough (6 steps matching the actual UI flow), transaction status tracking, 
history behaviour, FAQ (9 questions), and troubleshooting for 8 common issues. Screenshot placeholders are marked for future capture.

Tested: docs only, no code changes.
Closes #236 
Closes #237 
Closes #238 
Closes #239 