### PR TITLE
Feat/error boundaries tutorial keyboard shortcuts

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { ToastProvider } from "@/contexts/ToastContext";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import { ToastContainer } from "@/components/Toast";
 import ServiceWorkerRegistration from "@/components/ServiceWorkerRegistration";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 
 const ibmPlexMono = IBM_Plex_Mono({
   subsets: ["latin"],
@@ -47,7 +48,9 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
       <body className={`${ibmPlexMono.variable} ${spaceGrotesk.variable} font-ibm-plex-mono`}>
         <ThemeProvider>
           <ToastProvider>
-            {children}
+            <ErrorBoundary>
+              {children}
+            </ErrorBoundary>
             <ToastContainer />
           </ToastProvider>
         </ThemeProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import RecentOfframpsTable from "@/components/RecentOfframpsTable";
 import ProgressSteps from "@/components/ProgressSteps";
 import { Header } from "@/components/Header";
 import { TransactionProgressModal } from "@/components/TransactionProgressModal";
+import { Tutorial, useTutorial } from "@/components/Tutorial";
 import { useStellarWallet } from "@/hooks/useStellarWallet";
 import { usePollBridgeStatus } from "@/hooks/usePollBridgeStatus";
 import { usePollPayoutStatus } from "@/hooks/usePollPayoutStatus";
@@ -19,6 +20,8 @@ import type { WalletType } from "@/lib/stellar/wallet-adapter";
 export default function Home() {
   const { wallet, isConnected, isConnecting, error: walletError, connect, disconnect, signTransaction } =
     useStellarWallet();
+
+  const { open: tutorialOpen, openTutorial, closeTutorial } = useTutorial();
 
   const [amount, setAmount] = useState("");
   const [currency, setCurrency] = useState("");
@@ -259,6 +262,7 @@ export default function Home() {
 
   return (
     <main className="min-h-screen p-4 bg-[#0a0a0a]">
+      <Tutorial forceOpen={tutorialOpen} onClose={closeTutorial} />
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-accent focus:text-bg focus:border focus:border-accent"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,8 @@ import ProgressSteps from "@/components/ProgressSteps";
 import { Header } from "@/components/Header";
 import { TransactionProgressModal } from "@/components/TransactionProgressModal";
 import { Tutorial, useTutorial } from "@/components/Tutorial";
+import { KeyboardShortcutsModal } from "@/components/KeyboardShortcutsModal";
+import { useKeyboardShortcuts, type Shortcut } from "@/hooks/useKeyboardShortcuts";
 import { useStellarWallet } from "@/hooks/useStellarWallet";
 import { usePollBridgeStatus } from "@/hooks/usePollBridgeStatus";
 import { usePollPayoutStatus } from "@/hooks/usePollPayoutStatus";
@@ -22,6 +24,7 @@ export default function Home() {
     useStellarWallet();
 
   const { open: tutorialOpen, openTutorial, closeTutorial } = useTutorial();
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
 
   const [amount, setAmount] = useState("");
   const [currency, setCurrency] = useState("");
@@ -260,9 +263,50 @@ export default function Home() {
     setQuote(null);
   }, [disconnect]);
 
+  // ---------------------------------------------------------------------------
+  // Keyboard shortcuts
+  // ---------------------------------------------------------------------------
+  const shortcuts: Shortcut[] = [
+    {
+      key: "w",
+      ctrl: true,
+      description: "Connect / disconnect wallet",
+      action: () => (isConnected ? handleDisconnect() : handleConnect()),
+    },
+    {
+      key: "h",
+      description: "Show keyboard shortcuts",
+      action: () => setShortcutsOpen(true),
+    },
+    {
+      key: "?",
+      description: "Open tutorial",
+      action: openTutorial,
+    },
+    {
+      key: "Escape",
+      description: "Close modal / dialog",
+      action: () => {
+        setShortcutsOpen(false);
+        if (modalStep !== "idle") {
+          setModalStep("idle");
+          setModalError(undefined);
+          setModalTxHash(undefined);
+        }
+      },
+    },
+  ];
+
+  useKeyboardShortcuts(shortcuts);
+
   return (
     <main className="min-h-screen p-4 bg-[#0a0a0a]">
       <Tutorial forceOpen={tutorialOpen} onClose={closeTutorial} />
+      <KeyboardShortcutsModal
+        open={shortcutsOpen}
+        shortcuts={shortcuts}
+        onClose={() => setShortcutsOpen(false)}
+      />
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-accent focus:text-bg focus:border focus:border-accent"

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import React, { Component, type ErrorInfo, type ReactNode } from "react";
+import * as Sentry from "@sentry/react";
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+  onError?: (error: Error, info: ErrorInfo) => void;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+  eventId: string | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null, eventId: null };
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    const eventId = Sentry.captureException(error, {
+      extra: { componentStack: info.componentStack },
+    });
+    this.setState({ eventId: eventId ?? null });
+    this.props.onError?.(error, info);
+    console.error("[ErrorBoundary]", error, info.componentStack);
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false, error: null, eventId: null });
+  };
+
+  handleReport = () => {
+    if (this.state.eventId) {
+      Sentry.showReportDialog({ eventId: this.state.eventId });
+    }
+  };
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+
+    if (this.props.fallback) return this.props.fallback;
+
+    return (
+      <div
+        role="alert"
+        className="flex flex-col items-center justify-center min-h-[200px] p-8 border border-red-500/30 bg-red-500/5 text-center gap-4"
+      >
+        <p className="text-red-400 font-medium">Something went wrong</p>
+        <p className="text-[#888] text-sm max-w-sm">
+          {this.state.error?.message ?? "An unexpected error occurred."}
+        </p>
+        <div className="flex gap-3">
+          <button
+            onClick={this.handleReset}
+            className="px-4 py-2 text-sm border border-[#333] text-[#ccc] hover:border-[#555] transition-colors"
+          >
+            Try again
+          </button>
+          {this.state.eventId && (
+            <button
+              onClick={this.handleReport}
+              className="px-4 py-2 text-sm border border-[#333] text-[#888] hover:border-[#555] transition-colors"
+            >
+              Report issue
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/KeyboardShortcutsModal.tsx
+++ b/src/components/KeyboardShortcutsModal.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect } from "react";
+import type { Shortcut } from "@/hooks/useKeyboardShortcuts";
+
+interface Props {
+  open: boolean;
+  shortcuts: Shortcut[];
+  onClose: () => void;
+}
+
+function isMac() {
+  if (typeof navigator === "undefined") return false;
+  return navigator.platform.toUpperCase().includes("MAC");
+}
+
+function formatKey(shortcut: Shortcut): string {
+  const parts: string[] = [];
+  if (shortcut.ctrl) parts.push(isMac() ? "⌘" : "Ctrl");
+  if (shortcut.shift) parts.push("Shift");
+  parts.push(shortcut.key.toUpperCase());
+  return parts.join(" + ");
+}
+
+export function KeyboardShortcutsModal({ open, shortcuts, onClose }: Props) {
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="w-full max-w-sm border border-[#333] bg-[#111] p-6 flex flex-col gap-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-white font-medium text-sm">Keyboard shortcuts</h2>
+          <button
+            onClick={onClose}
+            aria-label="Close shortcuts modal"
+            className="text-[#555] hover:text-[#888] transition-colors text-lg leading-none"
+          >
+            ×
+          </button>
+        </div>
+
+        <ul className="flex flex-col gap-2">
+          {shortcuts.map((s) => (
+            <li key={s.key + String(s.ctrl) + String(s.shift)} className="flex items-center justify-between gap-4">
+              <span className="text-[#aaa] text-sm">{s.description}</span>
+              <kbd className="shrink-0 px-2 py-0.5 text-xs border border-[#333] text-[#888] font-mono">
+                {formatKey(s)}
+              </kbd>
+            </li>
+          ))}
+        </ul>
+
+        <p className="text-[#555] text-xs">
+          Shortcuts are disabled when a form field is focused.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+const STORAGE_KEY = "stellar-spend:tutorial-completed";
+
+const STEPS = [
+  {
+    title: "Connect your wallet",
+    description:
+      'Click "Connect Wallet" in the header to link your Freighter or Lobstr Stellar wallet.',
+  },
+  {
+    title: "Enter an amount",
+    description:
+      "Type the USDC/USDT amount you want to convert, or enter the fiat amount you want to receive.",
+  },
+  {
+    title: "Choose currency & bank",
+    description:
+      "Select your target fiat currency (NGN, KES, GHS…) and enter your bank account details.",
+  },
+  {
+    title: "Review the quote",
+    description:
+      "Check the live exchange rate and fees shown in the right panel before confirming.",
+  },
+  {
+    title: "Confirm & sign",
+    description:
+      "Click Send and approve the transaction in your wallet. Funds arrive in your bank within minutes.",
+  },
+];
+
+interface TutorialProps {
+  /** Force the tutorial open regardless of completion status (for re-access). */
+  forceOpen?: boolean;
+  onClose?: () => void;
+}
+
+export function Tutorial({ forceOpen = false, onClose }: TutorialProps) {
+  const [visible, setVisible] = useState(false);
+  const [step, setStep] = useState(0);
+
+  useEffect(() => {
+    if (forceOpen) {
+      setVisible(true);
+      setStep(0);
+      return;
+    }
+    try {
+      const done = localStorage.getItem(STORAGE_KEY);
+      if (!done) setVisible(true);
+    } catch {
+      // localStorage unavailable (SSR / private mode) — show tutorial
+      setVisible(true);
+    }
+  }, [forceOpen]);
+
+  const dismiss = useCallback(
+    (completed: boolean) => {
+      if (completed) {
+        try {
+          localStorage.setItem(STORAGE_KEY, "1");
+        } catch {
+          // ignore
+        }
+      }
+      setVisible(false);
+      onClose?.();
+    },
+    [onClose]
+  );
+
+  const handleNext = () => {
+    if (step < STEPS.length - 1) {
+      setStep((s) => s + 1);
+    } else {
+      dismiss(true);
+    }
+  };
+
+  const handleSkip = () => dismiss(true);
+
+  if (!visible) return null;
+
+  const current = STEPS[step];
+  const isLast = step === STEPS.length - 1;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Getting started tutorial"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+    >
+      <div className="w-full max-w-md border border-[#333] bg-[#111] p-6 flex flex-col gap-5">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-[#888] uppercase tracking-widest">
+            Getting started
+          </span>
+          <button
+            onClick={handleSkip}
+            aria-label="Skip tutorial"
+            className="text-xs text-[#555] hover:text-[#888] transition-colors"
+          >
+            Skip
+          </button>
+        </div>
+
+        {/* Step content */}
+        <div className="flex flex-col gap-2">
+          <p className="text-sm text-[#888]">
+            Step {step + 1} of {STEPS.length}
+          </p>
+          <h2 className="text-white font-medium">{current.title}</h2>
+          <p className="text-[#aaa] text-sm leading-relaxed">{current.description}</p>
+        </div>
+
+        {/* Progress dots */}
+        <div className="flex gap-1.5" aria-hidden="true">
+          {STEPS.map((_, i) => (
+            <span
+              key={i}
+              className={`h-1 flex-1 transition-colors ${
+                i <= step ? "bg-white" : "bg-[#333]"
+              }`}
+            />
+          ))}
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-3 justify-end">
+          {step > 0 && (
+            <button
+              onClick={() => setStep((s) => s - 1)}
+              className="px-4 py-2 text-sm border border-[#333] text-[#888] hover:border-[#555] transition-colors"
+            >
+              Back
+            </button>
+          )}
+          <button
+            onClick={handleNext}
+            className="px-4 py-2 text-sm border border-white text-white hover:bg-white hover:text-black transition-colors"
+          >
+            {isLast ? "Get started" : "Next"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Returns a function that re-opens the tutorial (for menu/help links). */
+export function useTutorial() {
+  const [open, setOpen] = useState(false);
+  const openTutorial = useCallback(() => setOpen(true), []);
+  const closeTutorial = useCallback(() => setOpen(false), []);
+  return { open, openTutorial, closeTutorial };
+}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useCallback } from "react";
+
+export interface Shortcut {
+  key: string;
+  /** Modifier: ctrl/cmd */
+  ctrl?: boolean;
+  /** Modifier: shift */
+  shift?: boolean;
+  description: string;
+  action: () => void;
+}
+
+/**
+ * Registers global keyboard shortcuts.
+ * Skips when focus is inside an input, textarea, or select to avoid conflicts.
+ */
+export function useKeyboardShortcuts(shortcuts: Shortcut[], enabled = true) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (!enabled) return;
+
+      // Don't fire shortcuts when typing in form fields
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      if ((e.target as HTMLElement)?.isContentEditable) return;
+
+      const isMac = navigator.platform.toUpperCase().includes("MAC");
+      const ctrlOrCmd = isMac ? e.metaKey : e.ctrlKey;
+
+      for (const shortcut of shortcuts) {
+        const keyMatch = e.key.toLowerCase() === shortcut.key.toLowerCase();
+        const ctrlMatch = shortcut.ctrl ? ctrlOrCmd : !ctrlOrCmd && !e.metaKey;
+        const shiftMatch = shortcut.shift ? e.shiftKey : !e.shiftKey;
+
+        if (keyMatch && ctrlMatch && shiftMatch) {
+          e.preventDefault();
+          shortcut.action();
+          return;
+        }
+      }
+    },
+    [enabled, shortcuts]
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [enabled, handleKeyDown]);
+}


### PR DESCRIPTION
Commit 1 — Error Boundaries                                                                                         
                                                                                                                      
  `src/components/ErrorBoundary.tsx` (new)                                                                            
                                                                                                                      
  - Class-based ErrorBoundary using componentDidCatch + getDerivedStateFromError                                      
  - Logs to Sentry via @sentry/react (already installed), captures event ID                                           
  - "Try again" button resets state; "Report issue" opens Sentry's feedback dialog when an event ID is available      
  - Accepts fallback, onError props for customization                                                                 
                                                                                                                      
  `src/app/layout.tsx` (modified)                                                                                     
                                                                                                                      
  - Wraps the entire app in <ErrorBoundary> for global coverage                                                       
                                                                                                                      
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                      
  Commit 2 — First-time Tutorial                                                                                      
                                                                                                                      
  `src/components/Tutorial.tsx` (new)                                                                                 
                                                                                                                      
  - 5-step guide: wallet connect → amount → currency/bank → quote review → confirm & sign                             
  - Auto-shows on first visit; completion stored in localStorage (stellar-spend:tutorial-completed)                   
  - Skip, Back, Next navigation; progress bar                                                                         
  - forceOpen prop + useTutorial() hook for re-triggering from help links                                             
  - Fully accessible: role="dialog", aria-modal, aria-label                                                           
                                                                                                                      
  `src/app/page.tsx` (modified)                                                                                       
                                                                                                                      
  - Imports and renders <Tutorial> with useTutorial() hook                                                            
                                                                                                                      
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                      
  Commit 3 — Keyboard Shortcuts                                                                                       
                                                                                                                      
  `src/hooks/useKeyboardShortcuts.ts` (new)                                                                           
                                                                                                                      
  - Generic hook that registers global keydown listener                                                               
  - Skips when focus is in INPUT/TEXTAREA/SELECT to avoid conflicts                                                   
  - Handles Ctrl vs ⌘ automatically on macOS                                                                          
                                                                                                                      
  `src/components/KeyboardShortcutsModal.tsx` (new)                                                                   
                                                                                                                      
  - Accessible modal listing all shortcuts with formatted <kbd> badges                                                
  - Closes on Escape or backdrop click                                                                                
                                                                                                                      
  `src/app/page.tsx` (modified)                                                                                       
                                                                                                                      
  - Shortcuts wired up:                                                                                               
    - Ctrl/⌘+W — connect/disconnect wallet                                                                            
    - H — open shortcuts help modal                                                                                   
    - ? — re-open tutorial                                                                                            
    - Escape — close any open modal/dialog 
closes #261 closes #262 closes #263