### PR TITLE
Feat/status badges realtime conversion

### DIFF
--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -7,6 +7,7 @@ import { Header } from "@/components/Header";
 import { CopyButton } from "@/components/CopyButton";
 import { cn } from "@/lib/cn";
 import { getCurrencyFlag } from "@/lib/currency-flags";
+import { StatusBadge } from "@/components/StatusBadge";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -33,19 +34,6 @@ function getCurrencySymbol(currency: string): string {
     KES: "KSh", GHS: "₵", ZAR: "R",
   };
   return symbols[currency.toUpperCase()] || currency.toUpperCase();
-}
-
-function StatusBadge({ status }: { status: Transaction["status"] }) {
-  const styles = {
-    pending: "bg-yellow-500/20 text-yellow-500 border-yellow-500/30",
-    completed: "bg-green-500/20 text-green-500 border-green-500/30",
-    failed: "bg-red-500/20 text-red-500 border-red-500/30",
-  };
-  return (
-    <span className={cn("inline-block px-2.5 py-0.5 text-[10px] tracking-widest uppercase font-semibold border", styles[status])}>
-      {status}
-    </span>
-  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/components/FormCard.tsx
+++ b/src/components/FormCard.tsx
@@ -6,6 +6,7 @@ import { buildQuote, calculateBridgeAmount } from "@/lib/offramp/utils/quote-fet
 import { getCurrencyFlag } from "@/lib/currency-flags";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { FormCardSkeleton } from "@/components/skeletons";
+import { useFxRate } from "@/hooks/useFxRate";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -368,21 +369,36 @@ function formatPayout(amount: string, currency: string): string {
 interface PayoutBoxProps {
   quote: QuoteResult;
   currency: string;
+  liveRate?: number | null;
+  flash?: boolean;
 }
 
-function PayoutBox({ quote, currency }: PayoutBoxProps) {
+function PayoutBox({ quote, currency, liveRate, flash }: PayoutBoxProps) {
+  const effectiveRate = liveRate ?? quote.rate;
+  const amount = parseFloat(quote.destinationAmount);
+  // Recalculate payout using live rate if available
+  const liveDestination =
+    liveRate && quote.rate > 0
+      ? ((amount / quote.rate) * liveRate).toFixed(2)
+      : quote.destinationAmount;
+
   return (
     <div className="border border-[#c9a962]/30 bg-[#c9a962]/5 px-4 py-3 flex items-center justify-between gap-4">
       <div className="flex flex-col gap-0.5">
         <span className="text-[10px] tracking-[0.18em] text-[#777777] uppercase">Estimated Payout</span>
         <span className="text-[10px] text-[#777777]">
           Rate: {currency.toUpperCase() === "NGN"
-            ? `${getCurrencySymbol(currency)}${new Intl.NumberFormat("en-NG").format(quote.rate)}`
-            : `${getCurrencySymbol(currency)} ${quote.rate.toFixed(4)}`} / USDC
+            ? `${getCurrencySymbol(currency)}${new Intl.NumberFormat("en-NG").format(effectiveRate)}`
+            : `${getCurrencySymbol(currency)} ${effectiveRate.toFixed(4)}`} / USDC
         </span>
       </div>
-      <span className="font-space-grotesk font-bold text-[#c9a962] text-lg tabular-nums">
-        {formatPayout(quote.destinationAmount, currency)}
+      <span
+        className={cn(
+          "font-space-grotesk font-bold text-lg tabular-nums transition-colors duration-300",
+          flash ? "text-white" : "text-[#c9a962]"
+        )}
+      >
+        {formatPayout(liveDestination, currency)}
       </span>
     </div>
   );
@@ -441,6 +457,8 @@ export function FormCard({
   const [institutions, setInstitutions] = useState<Institution[]>([]);
   const [quote, setQuote] = useState<QuoteResult | null>(null);
   const [gasFees, setGasFees] = useState<GasFeeOptions | null>(null);
+
+  const { rate: liveRate, flash: rateFlash } = useFxRate();
 
   const [isCurrenciesLoading, setIsCurrenciesLoading] = useState(false);
   const [isInstitutionsLoading, setIsInstitutionsLoading] = useState(false);
@@ -812,7 +830,7 @@ export function FormCard({
 
         <Field label="Account Name" value={accountName} loading={isVerifyingAccount} success={!!accountName} />
 
-        {quote && <PayoutBox quote={quote} currency={currency} />}
+        {quote && <PayoutBox quote={quote} currency={currency} liveRate={liveRate} flash={rateFlash} />}
 
         <button
           onClick={ctaState === "disconnected" ? onConnect : handleSubmitForm}

--- a/src/components/RecentOfframpsTable.tsx
+++ b/src/components/RecentOfframpsTable.tsx
@@ -5,6 +5,7 @@ import type { RecentOfframpRow } from "@/types/stellaramp";
 import { CopyButton } from "./CopyButton";
 import { getCurrencyFlag } from "@/lib/currency-flags";
 import { TransactionTableSkeleton } from "./skeletons";
+import { StatusBadge } from "./StatusBadge";
 
 // ---------------------------------------------------------------------------
 // Mock data — replaced by real TransactionStorage rows when wired up
@@ -39,21 +40,6 @@ function getCurrencyColumnHeader(rows: ReadonlyArray<RecentOfframpRow>): string 
   const firstCurrency = rows[0].currency;
   const allSameCurrency = rows.every(row => row.currency === firstCurrency);
   return allSameCurrency ? firstCurrency.toUpperCase() : "FIAT";
-}
-
-function StatusBadge({ status }: { status: RecentOfframpRow["status"] }) {
-  return (
-    <span
-      className={cn(
-        "inline-block px-2.5 py-0.5 text-[10px] tracking-widest uppercase font-semibold",
-        status === "SETTLING"
-          ? "bg-[#c9a962] text-[#0a0a0a]"
-          : "border border-white text-white bg-transparent"
-      )}
-    >
-      {status}
-    </span>
-  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from "react";
 import { cn } from "@/lib/cn";
 import { QuoteDisplaySkeleton } from "./skeletons";
+import { useFxRate } from "@/hooks/useFxRate";
 
 export interface RightPanelProps {
   isConnected: boolean;
@@ -87,8 +88,17 @@ function HeroPanel({
   isLoadingQuote,
   currency,
   onConnect,
-}: RightPanelProps) {
+  liveRate,
+  flash,
+}: RightPanelProps & { liveRate: number | null; flash: boolean }) {
   const hasAmount = amount && parseFloat(amount) > 0;
+
+  // Prefer live rate over quote rate for realtime payout calculation
+  const effectiveRate = liveRate ?? quote?.rate ?? null;
+  const liveDestination =
+    effectiveRate && hasAmount
+      ? (parseFloat(amount) * effectiveRate).toFixed(2)
+      : quote?.destinationAmount ?? null;
 
   // Derive hero content based on state
   let heroLabel: string;
@@ -113,14 +123,19 @@ function HeroPanel({
       </span>
     );
     heroMeta = "Fetching live rate...";
-  } else if (isConnected && hasAmount && quote) {
+  } else if (isConnected && hasAmount && (quote || liveDestination)) {
     heroLabel = "ESTIMATED PAYOUT";
     heroValue = (
-      <span className="text-[#c9a962]">
-        {formatFiat(quote.destinationAmount, quote.currency)}
+      <span
+        className={cn(
+          "text-[#c9a962] transition-colors duration-300",
+          flash && "text-white"
+        )}
+      >
+        {formatFiat(liveDestination ?? quote!.destinationAmount, currency || quote!.currency)}
       </span>
     );
-    heroMeta = `Rate: ${formatRate(quote.rate, quote.currency)}`;
+    heroMeta = `Rate: ${formatRate(effectiveRate ?? quote!.rate, currency || quote!.currency)}`;
   } else {
     heroLabel = "READY TO PAYOUT";
     heroValue = <span className="text-[#777777]">Enter amount</span>;
@@ -193,6 +208,7 @@ function BreakdownRow({ label, value, muted }: BreakdownRowProps) {
 
 export default function RightPanel(props: RightPanelProps) {
   const { quote, isConnected, isLoadingQuote, currency } = props;
+  const { rate: liveRate, flash } = useFxRate();
 
   // Show full skeleton when loading quote for the first time (no prior quote)
   if (isLoadingQuote && !quote) {
@@ -204,9 +220,16 @@ export default function RightPanel(props: RightPanelProps) {
       ? `${(parseFloat(props.amount) * 0.0035).toFixed(4)} USDC`
       : "0.35%";
 
+  // Use live rate for payout total when available
+  const effectiveRate = liveRate ?? quote?.rate ?? null;
+  const liveDestination =
+    effectiveRate && props.amount && parseFloat(props.amount) > 0
+      ? (parseFloat(props.amount) * effectiveRate).toFixed(2)
+      : null;
+
   const payoutTotal =
-    isConnected && quote && parseFloat(props.amount) > 0
-      ? formatFiat(quote.destinationAmount, quote.currency)
+    isConnected && (liveDestination || quote) && parseFloat(props.amount) > 0
+      ? formatFiat(liveDestination ?? quote!.destinationAmount, currency || quote!.currency)
       : isLoadingQuote
       ? "..."
       : `— ${currency.toUpperCase()}`;
@@ -214,7 +237,7 @@ export default function RightPanel(props: RightPanelProps) {
   return (
     <div className="flex flex-col gap-4 w-full">
       {/* Hero panel */}
-      <HeroPanel {...props} />
+      <HeroPanel {...props} liveRate={liveRate} flash={flash} />
 
       {/* Settlement breakdown */}
       <div className="border border-[#333333] bg-[#111111] p-5 flex flex-col gap-3">
@@ -243,8 +266,8 @@ export default function RightPanel(props: RightPanelProps) {
           </span>
           <span
             className={cn(
-              "font-space-grotesk font-bold tabular-nums leading-none",
-              isLoadingQuote ? "text-[#777777]" : "text-[#c9a962]"
+              "font-space-grotesk font-bold tabular-nums leading-none transition-colors duration-300",
+              isLoadingQuote ? "text-[#777777]" : flash ? "text-white" : "text-[#c9a962]"
             )}
             style={{ fontSize: "clamp(1.1rem, 2.5vw, 1.5rem)" }}
           >

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/cn";
+import type { RecentOfframpRow } from "@/types/stellaramp";
+import type { OfframpStep } from "@/types/stellaramp";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+type TransactionStatus = RecentOfframpRow["status"] | OfframpStep | "pending" | "completed" | "failed";
+
+interface StatusConfig {
+  label: string;
+  tooltip: string;
+  colorClasses: string;
+  dotClasses: string;
+  animate?: boolean;
+}
+
+const STATUS_CONFIG: Record<string, StatusConfig> = {
+  // RecentOfframpRow statuses
+  SETTLING: {
+    label: "Settling",
+    tooltip: "Funds are being transferred to your bank account.",
+    colorClasses: "bg-[#c9a962]/15 border border-[#c9a962]/60 text-[#c9a962]",
+    dotClasses: "bg-[#c9a962]",
+    animate: true,
+  },
+  COMPLETE: {
+    label: "Complete",
+    tooltip: "Transaction completed successfully.",
+    colorClasses: "bg-green-500/10 border border-green-500/40 text-green-400",
+    dotClasses: "bg-green-500",
+  },
+  // OfframpStep statuses
+  idle: {
+    label: "Idle",
+    tooltip: "No active transaction.",
+    colorClasses: "bg-[#333333]/40 border border-[#333333] text-[#777777]",
+    dotClasses: "bg-[#555555]",
+  },
+  initiating: {
+    label: "Initiating",
+    tooltip: "Preparing your transaction details.",
+    colorClasses: "bg-blue-500/10 border border-blue-500/40 text-blue-400",
+    dotClasses: "bg-blue-400",
+    animate: true,
+  },
+  "awaiting-signature": {
+    label: "Awaiting Signature",
+    tooltip: "Waiting for wallet approval.",
+    colorClasses: "bg-yellow-500/10 border border-yellow-500/40 text-yellow-400",
+    dotClasses: "bg-yellow-400",
+    animate: true,
+  },
+  submitting: {
+    label: "Submitting",
+    tooltip: "Broadcasting to the Stellar network.",
+    colorClasses: "bg-blue-500/10 border border-blue-500/40 text-blue-400",
+    dotClasses: "bg-blue-400",
+    animate: true,
+  },
+  processing: {
+    label: "Processing",
+    tooltip: "Waiting for on-chain confirmation.",
+    colorClasses: "bg-[#c9a962]/15 border border-[#c9a962]/60 text-[#c9a962]",
+    dotClasses: "bg-[#c9a962]",
+    animate: true,
+  },
+  settling: {
+    label: "Settling",
+    tooltip: "Transferring funds to your bank account.",
+    colorClasses: "bg-[#c9a962]/15 border border-[#c9a962]/60 text-[#c9a962]",
+    dotClasses: "bg-[#c9a962]",
+    animate: true,
+  },
+  success: {
+    label: "Success",
+    tooltip: "Transaction completed successfully.",
+    colorClasses: "bg-green-500/10 border border-green-500/40 text-green-400",
+    dotClasses: "bg-green-500",
+  },
+  error: {
+    label: "Failed",
+    tooltip: "Transaction failed. Please try again.",
+    colorClasses: "bg-red-500/10 border border-red-500/40 text-red-400",
+    dotClasses: "bg-red-500",
+  },
+  // Transaction storage statuses
+  pending: {
+    label: "Pending",
+    tooltip: "Transaction is pending.",
+    colorClasses: "bg-yellow-500/10 border border-yellow-500/40 text-yellow-400",
+    dotClasses: "bg-yellow-400",
+    animate: true,
+  },
+  completed: {
+    label: "Completed",
+    tooltip: "Transaction completed successfully.",
+    colorClasses: "bg-green-500/10 border border-green-500/40 text-green-400",
+    dotClasses: "bg-green-500",
+  },
+  failed: {
+    label: "Failed",
+    tooltip: "Transaction failed.",
+    colorClasses: "bg-red-500/10 border border-red-500/40 text-red-400",
+    dotClasses: "bg-red-500",
+  },
+};
+
+const FALLBACK_CONFIG: StatusConfig = {
+  label: "Unknown",
+  tooltip: "Status unknown.",
+  colorClasses: "bg-[#333333]/40 border border-[#333333] text-[#777777]",
+  dotClasses: "bg-[#555555]",
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface StatusBadgeProps {
+  status: TransactionStatus;
+  /** Show the status icon dot */
+  showIcon?: boolean;
+  className?: string;
+}
+
+export function StatusBadge({ status, showIcon = true, className }: StatusBadgeProps) {
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+  const config = STATUS_CONFIG[status] ?? FALLBACK_CONFIG;
+
+  return (
+    <span className="relative inline-flex items-center">
+      <span
+        role="status"
+        aria-label={`Transaction status: ${config.label}`}
+        title={config.tooltip}
+        onMouseEnter={() => setTooltipVisible(true)}
+        onMouseLeave={() => setTooltipVisible(false)}
+        onFocus={() => setTooltipVisible(true)}
+        onBlur={() => setTooltipVisible(false)}
+        tabIndex={0}
+        className={cn(
+          "inline-flex items-center gap-1.5 px-2.5 py-0.5",
+          "text-[10px] tracking-widest uppercase font-semibold",
+          "cursor-default select-none rounded-sm",
+          "focus:outline-none focus-visible:ring-1 focus-visible:ring-[#c9a962]",
+          config.colorClasses,
+          className
+        )}
+      >
+        {showIcon && (
+          <span
+            aria-hidden="true"
+            className={cn(
+              "inline-block h-1.5 w-1.5 rounded-full flex-shrink-0",
+              config.dotClasses,
+              config.animate && "animate-pulse"
+            )}
+          />
+        )}
+        {config.label}
+      </span>
+
+      {/* Tooltip */}
+      {tooltipVisible && (
+        <span
+          role="tooltip"
+          className={cn(
+            "absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-10",
+            "px-2.5 py-1.5 text-[10px] text-white bg-[#1a1a1a] border border-[#333333]",
+            "whitespace-nowrap pointer-events-none shadow-lg"
+          )}
+        >
+          {config.tooltip}
+          {/* Arrow */}
+          <span
+            aria-hidden="true"
+            className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-[#333333]"
+          />
+        </span>
+      )}
+    </span>
+  );
+}


### PR DESCRIPTION
feat: status badges + realtime conversion                                                                           
                                                                                                                      
  Summary                                                                                                             
                                                                                                                      
  This PR completes two features on the feat/status-badges-realtime-conversion branch:                                
                                                                                                                      
  1. Enhanced `StatusBadge` component (previous commit) — shared, accessible badge with color coding, icons, tooltips,
  and animated states                                                                                                 
  2. Realtime payout conversion (this PR's focus) — payout amounts in RightPanel and FormCard now update live as the  
  FX rate refreshes, without requiring user interaction                                                               
                                                                                                                      
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                      
  Changes                                                                                                             
                                                                                                                      
  `src/components/RightPanel.tsx`                                                                                     
                                                                                                                      
  - Calls useFxRate() internally — no prop drilling from page.tsx required                                            
  - Recomputes the hero payout value and settlement breakdown "Payout Total" as amount × liveRate on every 30-second  
  tick                                                                                                                
  - Falls back to quote.rate on first load (before the first live tick arrives)                                       
  - Both values flash text-white → text-[#c9a962] for 600ms on each rate update, giving the user a clear visual signal
  that the number changed                                                                                             
                                                                                                                      
  `src/components/FormCard.tsx`                                                                                       
                                                                                                                      
  - Calls useFxRate() inside FormCard                                                                                 
  - PayoutBox accepts new optional liveRate and flash props                                                           
  - Recalculates destinationAmount as (originalAmount / quoteRate) × liveRate — keeps the displayed fiat amount in    
  sync with the live rate without an extra API call                                                                   
  - Rate label and payout value both update in real-time with the same flash animation                                
                                                                                                                      
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                      
  How it works                                                                                                        
                                                                                                                      
  useFxRate (30s interval)                                                                                            
    └─ polls /api/offramp/rate                                                                                        
    └─ sets rate + triggers flash (600ms)                                                                             
          │                                                                                                           
          ├─ RightPanel                                                                                               
          │    ├─ hero: amount × liveRate  ← flashes white                                                            
          │    └─ breakdown total          ← flashes white                                                            
          │                                                                                                           
          └─ FormCard → PayoutBox                                                                                     
               ├─ rate label               ← shows liveRate                                                           
               └─ payout amount            ← (amount / quoteRate) × liveRate, flashes white                           
                                                                                                                      
  The existing useFxRate hook already handled polling, visibility-change re-fetching, and the flash boolean — this PR 
  just wires it into the two components that display conversion output.                                               
                                                                                                                      
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                      
  Testing                                                                                                             
                                                                                                                      
  - Connect wallet, enter an amount + currency → payout displays immediately from quote                               
  - Wait up to 30s (or mock the rate endpoint) → payout value and rate label update without any user action; both     
  flash briefly                                                                                                       
  - Disconnect / no amount → no regression, fallback states unchanged                                                 
  - StatusBadge renders correctly in RecentOfframpsTable and history/page.tsx for all status variants                 
                                                                                                                      
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                      
  Related                                                                                                             
                                                                                                                      
  - Closes the realtime conversion half of feat/status-badges-realtime-conversion                                     
  - useFxRate hook (src/hooks/useFxRate.ts) — unchanged, reused as-is                                                 
                                                                                                         
closes #256 closes #257