### PR TITLE
feat: integrate BankAccountInput, TransactionReceipt, QuoteComparison + tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9294,20 +9294,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -13443,20 +13429,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/ws": {

--- a/src/components/BankAccountInput.tsx
+++ b/src/components/BankAccountInput.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { validateBankField, type BankFieldType, type ValidationResult } from "@/lib/bank-validation";
+
+interface BankFieldProps {
+  type: BankFieldType;
+  value: string;
+  onChange: (value: string) => void;
+  label?: string;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+const DEFAULTS: Record<BankFieldType, { label: string; placeholder: string; maxLength: number }> = {
+  account: { label: "Account Number", placeholder: "e.g. 0123456789", maxLength: 20 },
+  routing: { label: "Routing Number (ABA)", placeholder: "9-digit ABA number", maxLength: 9 },
+  iban: { label: "IBAN", placeholder: "e.g. GB29NWBK60161331926819", maxLength: 34 },
+};
+
+export function BankField({ type, value, onChange, label, placeholder, disabled }: BankFieldProps) {
+  const [touched, setTouched] = useState(false);
+  const [result, setResult] = useState<ValidationResult>({ valid: true });
+
+  const defaults = DEFAULTS[type];
+
+  const handleChange = useCallback(
+    (raw: string) => {
+      onChange(raw);
+      if (touched) setResult(validateBankField(type, raw));
+    },
+    [type, touched, onChange]
+  );
+
+  const handleBlur = useCallback(() => {
+    setTouched(true);
+    setResult(validateBankField(type, value));
+  }, [type, value]);
+
+  const showError = touched && !result.valid;
+  const showSuccess = touched && result.valid && value.trim().length > 0;
+
+  const borderColor = showError
+    ? "#ef4444"
+    : showSuccess
+    ? "#22c55e"
+    : "var(--line)";
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      <label
+        htmlFor={`bank-field-${type}`}
+        style={{ fontSize: 11, color: "var(--muted)", letterSpacing: "0.08em" }}
+      >
+        {label ?? defaults.label}
+      </label>
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          height: 46,
+          border: "1px solid",
+          borderColor,
+          padding: "0 12px",
+          gap: 8,
+          transition: "border-color 0.15s",
+        }}
+      >
+        <input
+          id={`bank-field-${type}`}
+          type="text"
+          value={value}
+          onChange={(e) => handleChange(e.target.value)}
+          onBlur={handleBlur}
+          placeholder={placeholder ?? defaults.placeholder}
+          maxLength={defaults.maxLength}
+          disabled={disabled}
+          aria-invalid={showError}
+          aria-describedby={showError ? `bank-field-${type}-error` : undefined}
+          style={{
+            flex: 1,
+            background: "none",
+            border: 0,
+            outline: "none",
+            color: "var(--text)",
+            font: "inherit",
+            fontSize: 14,
+            opacity: disabled ? 0.5 : 1,
+            fontFamily: "var(--font-ibm-plex-mono)",
+            letterSpacing: "0.04em",
+          }}
+        />
+        {showSuccess && (
+          <span style={{ color: "#22c55e", fontSize: 14, flexShrink: 0 }} aria-hidden>
+            ✓
+          </span>
+        )}
+        {showError && (
+          <span style={{ color: "#ef4444", fontSize: 14, flexShrink: 0 }} aria-hidden>
+            ✕
+          </span>
+        )}
+      </div>
+
+      {showError && (
+        <p
+          id={`bank-field-${type}-error`}
+          role="alert"
+          style={{ fontSize: 11, color: "#ef4444", margin: 0 }}
+        >
+          {result.error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Composite component: full bank account form with mode switching
+// ---------------------------------------------------------------------------
+
+export type BankMode = "local" | "us" | "iban";
+
+interface BankAccountInputProps {
+  mode: BankMode;
+  onModeChange: (m: BankMode) => void;
+  accountNumber: string;
+  onAccountNumberChange: (v: string) => void;
+  routingNumber?: string;
+  onRoutingNumberChange?: (v: string) => void;
+  iban?: string;
+  onIbanChange?: (v: string) => void;
+  disabled?: boolean;
+}
+
+const MODE_LABELS: Record<BankMode, string> = {
+  local: "Local",
+  us: "US (ABA)",
+  iban: "IBAN",
+};
+
+export function BankAccountInput({
+  mode,
+  onModeChange,
+  accountNumber,
+  onAccountNumberChange,
+  routingNumber = "",
+  onRoutingNumberChange,
+  iban = "",
+  onIbanChange,
+  disabled,
+}: BankAccountInputProps) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      {/* Mode tabs */}
+      <div style={{ display: "flex", gap: 0, borderBottom: "1px solid var(--line)" }}>
+        {(["local", "us", "iban"] as BankMode[]).map((m) => (
+          <button
+            key={m}
+            onClick={() => onModeChange(m)}
+            style={{
+              fontSize: 11,
+              padding: "6px 14px",
+              border: "none",
+              borderBottom: mode === m ? "2px solid var(--accent)" : "2px solid transparent",
+              color: mode === m ? "var(--accent)" : "var(--muted)",
+              background: "none",
+              cursor: "pointer",
+              marginBottom: -1,
+              letterSpacing: "0.06em",
+            }}
+          >
+            {MODE_LABELS[m]}
+          </button>
+        ))}
+      </div>
+
+      {/* Fields */}
+      {mode === "local" && (
+        <BankField
+          type="account"
+          value={accountNumber}
+          onChange={onAccountNumberChange}
+          disabled={disabled}
+        />
+      )}
+
+      {mode === "us" && (
+        <>
+          <BankField
+            type="routing"
+            value={routingNumber}
+            onChange={onRoutingNumberChange ?? (() => {})}
+            disabled={disabled}
+          />
+          <BankField
+            type="account"
+            value={accountNumber}
+            onChange={onAccountNumberChange}
+            disabled={disabled}
+          />
+        </>
+      )}
+
+      {mode === "iban" && (
+        <BankField
+          type="iban"
+          value={iban}
+          onChange={onIbanChange ?? (() => {})}
+          disabled={disabled}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/FormCard.tsx
+++ b/src/components/FormCard.tsx
@@ -7,6 +7,7 @@ import { getCurrencyFlag } from "@/lib/currency-flags";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { FormCardSkeleton } from "@/components/skeletons";
 import { BankAccountInput, type BankMode } from "@/components/BankAccountInput";
+import { QuoteComparison, type ProviderQuote } from "@/components/QuoteComparison";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -389,6 +390,54 @@ function PayoutBox({ quote, currency }: PayoutBoxProps) {
   );
 }
 
+function buildProviderQuotes(quote: QuoteResult, currency: string): ProviderQuote[] {
+  const base = parseFloat(quote.destinationAmount);
+  const baseRate = quote.rate;
+  const baseFee = parseFloat(quote.bridgeFee ?? "0.5");
+
+  return [
+    {
+      id: "paycrest",
+      provider: "Paycrest",
+      rate: baseRate,
+      bridgeFee: (baseFee).toFixed(2),
+      payoutFee: "0.00",
+      totalFee: baseFee.toFixed(2),
+      estimatedTime: 300,
+      destinationAmount: base.toFixed(2),
+      currency,
+      rating: 5,
+      badge: "Best Rate",
+    },
+    {
+      id: "yellowcard",
+      provider: "Yellow Card",
+      rate: Math.round(baseRate * 0.992),
+      bridgeFee: (baseFee + 0.3).toFixed(2),
+      payoutFee: "0.50",
+      totalFee: (baseFee + 0.8).toFixed(2),
+      estimatedTime: 180,
+      destinationAmount: (base * 0.992).toFixed(2),
+      currency,
+      rating: 4,
+      badge: "Fastest",
+    },
+    {
+      id: "kotani",
+      provider: "Kotani Pay",
+      rate: Math.round(baseRate * 0.985),
+      bridgeFee: (baseFee + 0.1).toFixed(2),
+      payoutFee: "0.20",
+      totalFee: (baseFee + 0.3).toFixed(2),
+      estimatedTime: 420,
+      destinationAmount: (base * 0.985).toFixed(2),
+      currency,
+      rating: 4,
+      badge: "Lowest Fee",
+    },
+  ];
+}
+
 type CtaState = "disconnected" | "connecting" | "ready" | "submitting" | "invalid";
 
 function getCtaLabel(state: CtaState): string {
@@ -457,6 +506,7 @@ export function FormCard({
   const [accountError, setAccountError] = useState("");
   const [quoteError, setQuoteError] = useState("");
   const [verifyError, setVerifyError] = useState("");
+  const [selectedProviderId, setSelectedProviderId] = useState<string>("paycrest");
 
   // Track which fields have been touched (blurred) for validation UX
   const [touchedFields, setTouchedFields] = useState<Record<string, boolean>>({});
@@ -814,6 +864,15 @@ export function FormCard({
         <Field label="Account Name" value={accountName} loading={isVerifyingAccount} success={!!accountName} />
 
         {quote && <PayoutBox quote={quote} currency={currency} />}
+
+        {quote && (
+          <QuoteComparison
+            quotes={buildProviderQuotes(quote, currency)}
+            selectedId={selectedProviderId}
+            onSelect={setSelectedProviderId}
+            isLoading={isQuoteLoading}
+          />
+        )}
 
         <button
           onClick={ctaState === "disconnected" ? onConnect : handleSubmitForm}

--- a/src/components/FormCard.tsx
+++ b/src/components/FormCard.tsx
@@ -6,6 +6,7 @@ import { buildQuote, calculateBridgeAmount } from "@/lib/offramp/utils/quote-fet
 import { getCurrencyFlag } from "@/lib/currency-flags";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { FormCardSkeleton } from "@/components/skeletons";
+import { BankAccountInput, type BankMode } from "@/components/BankAccountInput";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -434,6 +435,9 @@ export function FormCard({
   const [feeMethod, setFeeMethod] = useState<FeeMethod>("USDC");
   const [currency, setCurrency] = useState("");
   const [accountNumber, setAccountNumber] = useState("");
+  const [bankMode, setBankMode] = useState<BankMode>("local");
+  const [routingNumber, setRoutingNumber] = useState("");
+  const [iban, setIban] = useState("");
   const [institution, setInstitution] = useState("");
   const [accountName, setAccountName] = useState("");
 
@@ -792,23 +796,20 @@ export function FormCard({
       </div>
 
       {/* Account number */}
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="accountNumber">Account Number</Label>
-        <input
-          id="accountNumber"
-          value={accountNumber}
-          onChange={handleAccountNumberChange}
-          onBlur={() => touchField("accountNumber")}
-          inputMode="numeric"
-          value={accountNumber}
-          onChange={(e) => onAccountNumberChange(e.target.value.replace(/\D/g, "").slice(0, 10))}
-          placeholder="0000000000"
-          error={accountError || verifyError}
-          success={validateAccountNumber(accountNumber) ? "Account number valid" : undefined}
-          touched={touchedFields["accountNumber"]}
-          disabled={!institution || !isConnected || isSubmitting}
-        />
-      </div>
+      <BankAccountInput
+        mode={bankMode}
+        onModeChange={setBankMode}
+        accountNumber={accountNumber}
+        onAccountNumberChange={(v) => {
+          setAccountNumber(v);
+          verifyAccount(v, institution, currency);
+        }}
+        routingNumber={routingNumber}
+        onRoutingNumberChange={setRoutingNumber}
+        iban={iban}
+        onIbanChange={setIban}
+        disabled={!institution || !isConnected || isSubmitting}
+      />
 
         <Field label="Account Name" value={accountName} loading={isVerifyingAccount} success={!!accountName} />
 

--- a/src/components/QuoteComparison.tsx
+++ b/src/components/QuoteComparison.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useState } from "react";
+
+export interface ProviderQuote {
+  id: string;
+  provider: string;
+  rate: number;
+  bridgeFee: string;
+  payoutFee: string;
+  totalFee: string;
+  estimatedTime: number; // seconds
+  destinationAmount: string;
+  currency: string;
+  rating: number; // 1-5
+  badge?: "Best Rate" | "Fastest" | "Lowest Fee";
+}
+
+interface QuoteComparisonProps {
+  quotes: ProviderQuote[];
+  selectedId?: string;
+  onSelect: (id: string) => void;
+  isLoading?: boolean;
+}
+
+function StarRating({ rating }: { rating: number }) {
+  return (
+    <span style={{ display: "inline-flex", gap: 2 }} aria-label={`${rating} out of 5 stars`}>
+      {[1, 2, 3, 4, 5].map((s) => (
+        <span
+          key={s}
+          style={{
+            fontSize: 10,
+            color: s <= rating ? "var(--accent)" : "var(--line)",
+          }}
+        >
+          ★
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function formatTime(seconds: number): string {
+  if (seconds < 60) return `~${seconds}s`;
+  const mins = Math.round(seconds / 60);
+  return `~${mins}m`;
+}
+
+export function QuoteComparison({ quotes, selectedId, onSelect, isLoading }: QuoteComparisonProps) {
+  const [sortBy, setSortBy] = useState<"rate" | "fee" | "time">("rate");
+
+  const sorted = [...quotes].sort((a, b) => {
+    if (sortBy === "rate") return b.rate - a.rate;
+    if (sortBy === "fee") return parseFloat(a.totalFee) - parseFloat(b.totalFee);
+    return a.estimatedTime - b.estimatedTime;
+  });
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: "16px 0" }}>
+        {[0, 1, 2].map((i) => (
+          <div
+            key={i}
+            className="skeleton"
+            style={{ height: 72, marginBottom: 8, borderRadius: 4 }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (!quotes.length) return null;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      {/* Sort controls */}
+      <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+        <span style={{ fontSize: 11, color: "var(--muted)" }}>Sort by:</span>
+        {(["rate", "fee", "time"] as const).map((opt) => (
+          <button
+            key={opt}
+            onClick={() => setSortBy(opt)}
+            style={{
+              fontSize: 11,
+              padding: "3px 8px",
+              border: "1px solid",
+              borderColor: sortBy === opt ? "var(--accent)" : "var(--line)",
+              color: sortBy === opt ? "var(--accent)" : "var(--muted)",
+              background: "none",
+              cursor: "pointer",
+              textTransform: "capitalize",
+            }}
+          >
+            {opt === "rate" ? "Best Rate" : opt === "fee" ? "Lowest Fee" : "Fastest"}
+          </button>
+        ))}
+      </div>
+
+      {/* Table header */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 80px 80px 70px 60px 32px",
+          gap: 8,
+          padding: "6px 12px",
+          fontSize: 10,
+          color: "var(--muted)",
+          letterSpacing: "0.06em",
+          textTransform: "uppercase",
+          borderBottom: "1px solid var(--line)",
+        }}
+      >
+        <span>Provider</span>
+        <span>You Receive</span>
+        <span>Total Fee</span>
+        <span>Est. Time</span>
+        <span>Rating</span>
+        <span />
+      </div>
+
+      {/* Rows */}
+      {sorted.map((q) => {
+        const isSelected = q.id === selectedId;
+        return (
+          <button
+            key={q.id}
+            onClick={() => onSelect(q.id)}
+            aria-pressed={isSelected}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 80px 80px 70px 60px 32px",
+              gap: 8,
+              padding: "10px 12px",
+              border: "1px solid",
+              borderColor: isSelected ? "var(--accent)" : "var(--line)",
+              background: isSelected ? "color-mix(in srgb, var(--accent) 8%, var(--panel))" : "var(--panel)",
+              cursor: "pointer",
+              textAlign: "left",
+              alignItems: "center",
+              transition: "border-color 0.15s, background 0.15s",
+            }}
+          >
+            {/* Provider name + badge */}
+            <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+              <span style={{ fontSize: 13, color: "var(--text)", fontWeight: 500 }}>
+                {q.provider}
+              </span>
+              {q.badge && (
+                <span
+                  style={{
+                    fontSize: 9,
+                    padding: "1px 5px",
+                    background: "var(--accent)",
+                    color: "#000",
+                    borderRadius: 2,
+                    width: "fit-content",
+                    letterSpacing: "0.05em",
+                    textTransform: "uppercase",
+                  }}
+                >
+                  {q.badge}
+                </span>
+              )}
+            </div>
+
+            {/* Destination amount */}
+            <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+              <span style={{ fontSize: 13, color: "var(--text)" }}>
+                {parseFloat(q.destinationAmount).toLocaleString()}
+              </span>
+              <span style={{ fontSize: 10, color: "var(--muted)" }}>{q.currency}</span>
+            </div>
+
+            {/* Fees breakdown */}
+            <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+              <span style={{ fontSize: 13, color: "var(--text)" }}>{q.totalFee} USDC</span>
+              <span style={{ fontSize: 10, color: "var(--muted)" }}>
+                Bridge: {q.bridgeFee} · Payout: {q.payoutFee}
+              </span>
+            </div>
+
+            {/* Estimated time */}
+            <span style={{ fontSize: 13, color: "var(--text)" }}>
+              {formatTime(q.estimatedTime)}
+            </span>
+
+            {/* Rating */}
+            <StarRating rating={q.rating} />
+
+            {/* Selection indicator */}
+            <div
+              style={{
+                width: 16,
+                height: 16,
+                borderRadius: "50%",
+                border: "2px solid",
+                borderColor: isSelected ? "var(--accent)" : "var(--line)",
+                background: isSelected ? "var(--accent)" : "transparent",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+              }}
+            >
+              {isSelected && (
+                <span style={{ fontSize: 8, color: "#000", lineHeight: 1 }}>✓</span>
+              )}
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/TransactionProgressModal.tsx
+++ b/src/components/TransactionProgressModal.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/cn";
 import type { OfframpStep } from "@/types/stellaramp";
 import { CopyButton } from "./CopyButton";
 import { useKeyboardNavigation } from "@/hooks/useKeyboardNavigation";
+import { TransactionReceipt, type ReceiptData } from "./TransactionReceipt";
 
 // ---------------------------------------------------------------------------
 // Per-step metadata: label, sub-message, ETA seconds
@@ -85,6 +86,7 @@ export type TransactionProgressModalProps = {
   step: OfframpStep;
   errorMessage?: string;
   txHash?: string;
+  receipt?: ReceiptData;
   onClose: () => void;
 };
 
@@ -92,6 +94,7 @@ export function TransactionProgressModal({
   step,
   errorMessage,
   txHash,
+  receipt,
   onClose,
 }: TransactionProgressModalProps) {
   const [isVisible, setIsVisible] = useState(false);
@@ -260,24 +263,30 @@ export function TransactionProgressModal({
           )}
 
           {/* Success details */}
-          {step === "success" && txHash && (
-            <div className="w-full flex flex-col gap-2 items-center mt-2">
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-[#777777]">TX Hash:</span>
-                <code className="text-xs text-[#c9a962] font-mono">
-                  {txHash.slice(0, 8)}…{txHash.slice(-8)}
-                </code>
-                <CopyButton text={txHash} label="" className="text-xs" />
+          {step === "success" && (
+            receipt ? (
+              <div className="w-full mt-2">
+                <TransactionReceipt data={receipt} />
               </div>
-              <a
-                href={`https://stellar.expert/explorer/public/tx/${txHash}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs text-[#c9a962] hover:text-[#d4b982] transition-colors underline decoration-dotted"
-              >
-                View on Stellar Explorer →
-              </a>
-            </div>
+            ) : txHash ? (
+              <div className="w-full flex flex-col gap-2 items-center mt-2">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-[#777777]">TX Hash:</span>
+                  <code className="text-xs text-[#c9a962] font-mono">
+                    {txHash.slice(0, 8)}…{txHash.slice(-8)}
+                  </code>
+                  <CopyButton text={txHash} label="" className="text-xs" />
+                </div>
+                <a
+                  href={`https://stellar.expert/explorer/public/tx/${txHash}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-[#c9a962] hover:text-[#d4b982] transition-colors underline decoration-dotted"
+                >
+                  View on Stellar Explorer →
+                </a>
+              </div>
+            ) : null
           )}
 
           {/* Dismiss */}

--- a/src/components/TransactionReceipt.tsx
+++ b/src/components/TransactionReceipt.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useRef } from "react";
+
+export interface ReceiptData {
+  txHash: string;
+  orderId?: string;
+  amount: string;
+  currency: string;
+  destinationAmount: string;
+  bridgeFee: string;
+  payoutFee: string;
+  rate: number;
+  provider: string;
+  bankName: string;
+  accountNumber: string;
+  timestamp: number;
+  status: "completed" | "pending" | "failed";
+}
+
+interface TransactionReceiptProps {
+  data: ReceiptData;
+  onClose?: () => void;
+}
+
+/** Minimal deterministic QR-like grid from a string — decorative only */
+function QRPlaceholder({ value }: { value: string }) {
+  const size = 9;
+  const cells: boolean[] = [];
+  for (let i = 0; i < size * size; i++) {
+    const charCode = value.charCodeAt(i % value.length);
+    cells.push((charCode + i) % 3 !== 0);
+  }
+  // Fixed corner finder patterns
+  const corners = new Set([0, 1, 2, 3, 4, 5, 6, 9, 15, 18, 24, 27, 33, 36, 42, 45, 46, 47, 48, 49, 50, 51, 54, 60, 63, 69, 72, 73, 74, 75, 76, 77, 78]);
+  return (
+    <div
+      aria-label={`QR code for transaction ${value.slice(0, 8)}…`}
+      role="img"
+      style={{
+        display: "grid",
+        gridTemplateColumns: `repeat(${size}, 1fr)`,
+        gap: 1,
+        width: 72,
+        height: 72,
+        padding: 4,
+        background: "#fff",
+        border: "1px solid var(--line)",
+      }}
+    >
+      {cells.map((filled, i) => (
+        <div
+          key={i}
+          style={{
+            background: corners.has(i) || filled ? "#000" : "#fff",
+            borderRadius: 0,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function Row({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "flex-start",
+        gap: 12,
+        padding: "8px 0",
+        borderBottom: "1px solid var(--line)",
+      }}
+    >
+      <span style={{ fontSize: 11, color: "var(--muted)", flexShrink: 0 }}>{label}</span>
+      <span
+        style={{
+          fontSize: 12,
+          color: "var(--text)",
+          textAlign: "right",
+          wordBreak: "break-all",
+          fontFamily: mono ? "var(--font-ibm-plex-mono)" : "inherit",
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+const STATUS_COLOR: Record<ReceiptData["status"], string> = {
+  completed: "#22c55e",
+  pending: "var(--accent)",
+  failed: "#ef4444",
+};
+
+export function TransactionReceipt({ data, onClose }: TransactionReceiptProps) {
+  const receiptRef = useRef<HTMLDivElement>(null);
+
+  const date = new Date(data.timestamp).toLocaleString();
+  const shortHash = `${data.txHash.slice(0, 8)}…${data.txHash.slice(-6)}`;
+  const shareText = `Stellar-Spend transaction ${shortHash} — ${data.amount} USDC → ${data.destinationAmount} ${data.currency}`;
+
+  function handlePrint() {
+    if (!receiptRef.current) return;
+    const win = window.open("", "_blank", "width=480,height=700");
+    if (!win) return;
+    win.document.write(`
+      <html><head><title>Receipt ${shortHash}</title>
+      <style>
+        body { font-family: monospace; font-size: 12px; padding: 24px; color: #000; }
+        .row { display: flex; justify-content: space-between; padding: 6px 0; border-bottom: 1px solid #ddd; }
+        .label { color: #666; }
+        h2 { font-size: 16px; margin-bottom: 16px; }
+      </style></head><body>
+      ${receiptRef.current.innerHTML}
+      </body></html>
+    `);
+    win.document.close();
+    win.focus();
+    win.print();
+    win.close();
+  }
+
+  async function handleShare() {
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: "Transaction Receipt", text: shareText });
+      } catch {
+        // user cancelled
+      }
+    } else {
+      await navigator.clipboard.writeText(shareText);
+      alert("Receipt details copied to clipboard.");
+    }
+  }
+
+  return (
+    <div
+      style={{
+        background: "var(--panel)",
+        border: "1px solid var(--line)",
+        padding: 24,
+        maxWidth: 480,
+        width: "100%",
+      }}
+    >
+      {/* Header */}
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 20 }}>
+        <div>
+          <div style={{ fontSize: 11, color: "var(--muted)", letterSpacing: "0.08em", marginBottom: 4 }}>
+            TRANSACTION RECEIPT
+          </div>
+          <div style={{ fontSize: 20, color: "var(--text)", fontWeight: 600 }}>
+            {data.amount} USDC
+          </div>
+          <div style={{ fontSize: 13, color: "var(--muted)", marginTop: 2 }}>
+            → {parseFloat(data.destinationAmount).toLocaleString()} {data.currency}
+          </div>
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 8 }}>
+          <span
+            style={{
+              fontSize: 11,
+              padding: "3px 8px",
+              border: "1px solid",
+              borderColor: STATUS_COLOR[data.status],
+              color: STATUS_COLOR[data.status],
+              textTransform: "uppercase",
+              letterSpacing: "0.06em",
+            }}
+          >
+            {data.status}
+          </span>
+          {onClose && (
+            <button
+              onClick={onClose}
+              aria-label="Close receipt"
+              style={{ fontSize: 18, color: "var(--muted)", lineHeight: 1 }}
+            >
+              ×
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Details */}
+      <div ref={receiptRef}>
+        <Row label="Date" value={date} />
+        <Row label="Tx Hash" value={shortHash} mono />
+        {data.orderId && <Row label="Order ID" value={data.orderId} mono />}
+        <Row label="Provider" value={data.provider} />
+        <Row label="Exchange Rate" value={`1 USDC = ${data.rate.toLocaleString()} ${data.currency}`} />
+        <Row label="Bridge Fee" value={`${data.bridgeFee} USDC`} />
+        <Row label="Payout Fee" value={`${data.payoutFee} USDC`} />
+        <Row label="Bank" value={data.bankName} />
+        <Row label="Account" value={`****${data.accountNumber.slice(-4)}`} mono />
+      </div>
+
+      {/* QR + Actions */}
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-end", marginTop: 20 }}>
+        <QRPlaceholder value={data.txHash} />
+
+        <div style={{ display: "flex", gap: 8 }}>
+          <button
+            onClick={handlePrint}
+            style={{
+              fontSize: 12,
+              padding: "8px 14px",
+              border: "1px solid var(--line)",
+              color: "var(--text)",
+              background: "none",
+              cursor: "pointer",
+            }}
+          >
+            Print
+          </button>
+          <button
+            onClick={handleShare}
+            style={{
+              fontSize: 12,
+              padding: "8px 14px",
+              border: "1px solid var(--accent)",
+              color: "var(--accent)",
+              background: "none",
+              cursor: "pointer",
+            }}
+          >
+            Share
+          </button>
+        </div>
+      </div>
+
+      {/* Full hash */}
+      <div
+        style={{
+          marginTop: 12,
+          padding: "8px 10px",
+          background: "var(--bg)",
+          fontSize: 10,
+          color: "var(--muted)",
+          wordBreak: "break-all",
+          fontFamily: "var(--font-ibm-plex-mono)",
+        }}
+      >
+        {data.txHash}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/bank-validation.ts
+++ b/src/lib/bank-validation.ts
@@ -1,0 +1,57 @@
+/**
+ * Bank account validation utilities.
+ * Supports: account number (generic), US routing number (ABA), IBAN.
+ */
+
+export type ValidationResult = { valid: boolean; error?: string };
+
+/** Generic account number: 4–20 digits */
+export function validateAccountNumber(value: string): ValidationResult {
+  const digits = value.replace(/\s/g, "");
+  if (!digits) return { valid: false, error: "Account number is required." };
+  if (!/^\d+$/.test(digits)) return { valid: false, error: "Account number must contain only digits." };
+  if (digits.length < 4) return { valid: false, error: "Account number is too short (min 4 digits)." };
+  if (digits.length > 20) return { valid: false, error: "Account number is too long (max 20 digits)." };
+  return { valid: true };
+}
+
+/** US ABA routing number: 9 digits with checksum */
+export function validateRoutingNumber(value: string): ValidationResult {
+  const digits = value.replace(/\s/g, "");
+  if (!digits) return { valid: false, error: "Routing number is required." };
+  if (!/^\d{9}$/.test(digits)) return { valid: false, error: "Routing number must be exactly 9 digits." };
+
+  // ABA checksum: 3*(d0+d3+d6) + 7*(d1+d4+d7) + (d2+d5+d8) must be divisible by 10
+  const d = digits.split("").map(Number);
+  const sum = 3 * (d[0] + d[3] + d[6]) + 7 * (d[1] + d[4] + d[7]) + (d[2] + d[5] + d[8]);
+  if (sum % 10 !== 0) return { valid: false, error: "Invalid routing number (checksum failed)." };
+  return { valid: true };
+}
+
+/** IBAN: country code + check digits + BBAN, validated via MOD-97 */
+export function validateIBAN(value: string): ValidationResult {
+  const iban = value.replace(/\s/g, "").toUpperCase();
+  if (!iban) return { valid: false, error: "IBAN is required." };
+  if (!/^[A-Z]{2}\d{2}[A-Z0-9]{1,30}$/.test(iban)) {
+    return { valid: false, error: "IBAN format is invalid. Expected: CC##BBAN (e.g. GB29NWBK60161331926819)." };
+  }
+  // MOD-97 check
+  const rearranged = iban.slice(4) + iban.slice(0, 4);
+  const numeric = rearranged.replace(/[A-Z]/g, (c) => String(c.charCodeAt(0) - 55));
+  let remainder = 0;
+  for (const ch of numeric) {
+    remainder = (remainder * 10 + parseInt(ch, 10)) % 97;
+  }
+  if (remainder !== 1) return { valid: false, error: "IBAN check digits are invalid." };
+  return { valid: true };
+}
+
+export type BankFieldType = "account" | "routing" | "iban";
+
+export function validateBankField(type: BankFieldType, value: string): ValidationResult {
+  switch (type) {
+    case "account": return validateAccountNumber(value);
+    case "routing": return validateRoutingNumber(value);
+    case "iban": return validateIBAN(value);
+  }
+}

--- a/src/test/BankAccountInput.test.tsx
+++ b/src/test/BankAccountInput.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { BankAccountInput, BankField } from "@/components/BankAccountInput";
+
+const noop = vi.fn();
+
+describe("BankField", () => {
+  it("renders label and input", () => {
+    render(<BankField type="account" value="" onChange={noop} />);
+    expect(screen.getByLabelText(/account number/i)).toBeInTheDocument();
+  });
+
+  it("shows error message after blur with invalid value", async () => {
+    render(<BankField type="account" value="ab" onChange={noop} />);
+    await userEvent.tab(); // focus then blur
+    const input = screen.getByRole("textbox");
+    await userEvent.click(input);
+    await userEvent.tab();
+    expect(screen.queryByRole("alert")).toBeInTheDocument();
+  });
+
+  it("shows success checkmark for valid account number after blur", async () => {
+    const { rerender } = render(<BankField type="account" value="" onChange={noop} />);
+    const input = screen.getByRole("textbox");
+    await userEvent.click(input);
+    rerender(<BankField type="account" value="0123456789" onChange={noop} />);
+    await userEvent.tab();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("respects disabled prop", () => {
+    render(<BankField type="account" value="" onChange={noop} disabled />);
+    expect(screen.getByRole("textbox")).toBeDisabled();
+  });
+
+  it("renders routing number field with correct placeholder", () => {
+    render(<BankField type="routing" value="" onChange={noop} />);
+    expect(screen.getByPlaceholderText(/9-digit/i)).toBeInTheDocument();
+  });
+
+  it("renders IBAN field with correct placeholder", () => {
+    render(<BankField type="iban" value="" onChange={noop} />);
+    expect(screen.getByPlaceholderText(/GB29/i)).toBeInTheDocument();
+  });
+});
+
+describe("BankAccountInput", () => {
+  const baseProps = {
+    mode: "local" as const,
+    onModeChange: noop,
+    accountNumber: "",
+    onAccountNumberChange: noop,
+  };
+
+  it("renders mode tabs", () => {
+    render(<BankAccountInput {...baseProps} />);
+    expect(screen.getByText("Local")).toBeInTheDocument();
+    expect(screen.getByText("US (ABA)")).toBeInTheDocument();
+    expect(screen.getByText("IBAN")).toBeInTheDocument();
+  });
+
+  it("calls onModeChange when a tab is clicked", async () => {
+    const onModeChange = vi.fn();
+    render(<BankAccountInput {...baseProps} onModeChange={onModeChange} />);
+    await userEvent.click(screen.getByText("IBAN"));
+    expect(onModeChange).toHaveBeenCalledWith("iban");
+  });
+
+  it("shows account field in local mode", () => {
+    render(<BankAccountInput {...baseProps} mode="local" />);
+    expect(screen.getByLabelText(/account number/i)).toBeInTheDocument();
+  });
+
+  it("shows routing + account fields in US mode", () => {
+    render(<BankAccountInput {...baseProps} mode="us" routingNumber="" onRoutingNumberChange={noop} />);
+    expect(screen.getByLabelText(/routing number/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/account number/i)).toBeInTheDocument();
+  });
+
+  it("shows IBAN field in iban mode", () => {
+    render(<BankAccountInput {...baseProps} mode="iban" iban="" onIbanChange={noop} />);
+    expect(screen.getByLabelText(/iban/i)).toBeInTheDocument();
+  });
+});

--- a/src/test/QuoteComparison.test.tsx
+++ b/src/test/QuoteComparison.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { QuoteComparison, type ProviderQuote } from "@/components/QuoteComparison";
+
+const noop = vi.fn();
+
+const mockQuotes: ProviderQuote[] = [
+  {
+    id: "paycrest",
+    provider: "Paycrest",
+    rate: 1600,
+    bridgeFee: "0.50",
+    payoutFee: "0.00",
+    totalFee: "0.50",
+    estimatedTime: 300,
+    destinationAmount: "159500.00",
+    currency: "NGN",
+    rating: 5,
+    badge: "Best Rate",
+  },
+  {
+    id: "yellowcard",
+    provider: "Yellow Card",
+    rate: 1587,
+    bridgeFee: "0.80",
+    payoutFee: "0.50",
+    totalFee: "1.30",
+    estimatedTime: 180,
+    destinationAmount: "158200.00",
+    currency: "NGN",
+    rating: 4,
+    badge: "Fastest",
+  },
+];
+
+describe("QuoteComparison", () => {
+  it("renders nothing when quotes array is empty", () => {
+    const { container } = render(
+      <QuoteComparison quotes={[]} selectedId={undefined} onSelect={noop} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a row for each provider", () => {
+    render(<QuoteComparison quotes={mockQuotes} selectedId="paycrest" onSelect={noop} />);
+    expect(screen.getByText("Paycrest")).toBeInTheDocument();
+    expect(screen.getByText("Yellow Card")).toBeInTheDocument();
+  });
+
+  it("renders provider badges", () => {
+    render(<QuoteComparison quotes={mockQuotes} selectedId="paycrest" onSelect={noop} />);
+    // "Best Rate" appears as both a sort button and a badge span — at least 2 occurrences
+    expect(screen.getAllByText("Best Rate").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("Fastest").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("calls onSelect with provider id when row is clicked", async () => {
+    const onSelect = vi.fn();
+    render(<QuoteComparison quotes={mockQuotes} selectedId="paycrest" onSelect={onSelect} />);
+    await userEvent.click(screen.getByText("Yellow Card").closest("button")!);
+    expect(onSelect).toHaveBeenCalledWith("yellowcard");
+  });
+
+  it("marks selected row with aria-pressed=true", () => {
+    render(<QuoteComparison quotes={mockQuotes} selectedId="paycrest" onSelect={noop} />);
+    const buttons = screen.getAllByRole("button", { pressed: true });
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0]).toHaveTextContent("Paycrest");
+  });
+
+  it("shows skeleton rows when isLoading is true", () => {
+    const { container } = render(
+      <QuoteComparison quotes={mockQuotes} selectedId="paycrest" onSelect={noop} isLoading />
+    );
+    const skeletons = container.querySelectorAll(".skeleton");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("renders sort controls", () => {
+    render(<QuoteComparison quotes={mockQuotes} selectedId="paycrest" onSelect={noop} />);
+    // Sort buttons exist (may share text with badges)
+    expect(screen.getAllByText("Best Rate").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Lowest Fee")).toBeInTheDocument();
+    expect(screen.getAllByText("Fastest").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("sorts by fee when Lowest Fee sort is clicked", async () => {
+    render(<QuoteComparison quotes={mockQuotes} selectedId="paycrest" onSelect={noop} />);
+    await userEvent.click(screen.getByRole("button", { name: /lowest fee/i }));
+    const rows = screen.getAllByRole("button", { pressed: false });
+    // After sorting by fee, Paycrest (0.50) should appear before Yellow Card (1.30)
+    const providerNames = rows.map((r) => r.textContent);
+    const paycrestIdx = providerNames.findIndex((t) => t?.includes("Paycrest"));
+    const yellowIdx = providerNames.findIndex((t) => t?.includes("Yellow Card"));
+    expect(paycrestIdx).toBeLessThan(yellowIdx);
+  });
+});

--- a/src/test/TransactionReceipt.test.tsx
+++ b/src/test/TransactionReceipt.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { TransactionReceipt, type ReceiptData } from "@/components/TransactionReceipt";
+
+const mockReceipt: ReceiptData = {
+  txHash: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+  orderId: "order-xyz-001",
+  amount: "100",
+  currency: "NGN",
+  destinationAmount: "159500.00",
+  bridgeFee: "0.50",
+  payoutFee: "0.00",
+  rate: 1595,
+  provider: "Paycrest",
+  bankName: "First Bank",
+  accountNumber: "0123456789",
+  timestamp: new Date("2026-04-24T11:00:00Z").getTime(),
+  status: "completed",
+};
+
+describe("TransactionReceipt", () => {
+  it("renders the amount and currency", () => {
+    render(<TransactionReceipt data={mockReceipt} />);
+    expect(screen.getByText("100 USDC")).toBeInTheDocument();
+  });
+
+  it("renders destination amount", () => {
+    render(<TransactionReceipt data={mockReceipt} />);
+    expect(screen.getByText(/159,500/)).toBeInTheDocument();
+  });
+
+  it("renders status badge", () => {
+    render(<TransactionReceipt data={mockReceipt} />);
+    expect(screen.getByText("completed")).toBeInTheDocument();
+  });
+
+  it("renders provider name", () => {
+    render(<TransactionReceipt data={mockReceipt} />);
+    expect(screen.getByText("Paycrest")).toBeInTheDocument();
+  });
+
+  it("masks account number to last 4 digits", () => {
+    render(<TransactionReceipt data={mockReceipt} />);
+    expect(screen.getByText("****6789")).toBeInTheDocument();
+  });
+
+  it("renders order ID row when provided", () => {
+    render(<TransactionReceipt data={mockReceipt} />);
+    expect(screen.getByText("order-xyz-001")).toBeInTheDocument();
+  });
+
+  it("does not render order ID row when omitted", () => {
+    const { orderId: _, ...noOrder } = mockReceipt;
+    render(<TransactionReceipt data={noOrder} />);
+    expect(screen.queryByText("order-xyz-001")).not.toBeInTheDocument();
+  });
+
+  it("renders shortened tx hash in the full hash footer", () => {
+    render(<TransactionReceipt data={mockReceipt} />);
+    expect(screen.getByText(mockReceipt.txHash)).toBeInTheDocument();
+  });
+
+  it("calls onClose when close button is clicked", async () => {
+    const onClose = vi.fn();
+    render(<TransactionReceipt data={mockReceipt} onClose={onClose} />);
+    await userEvent.click(screen.getByRole("button", { name: /close receipt/i }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not render close button when onClose is not provided", () => {
+    render(<TransactionReceipt data={mockReceipt} />);
+    expect(screen.queryByRole("button", { name: /close receipt/i })).not.toBeInTheDocument();
+  });
+
+  it("renders Print and Share buttons", () => {
+    render(<TransactionReceipt data={mockReceipt} />);
+    expect(screen.getByRole("button", { name: /print/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /share/i })).toBeInTheDocument();
+  });
+
+  it("renders QR placeholder with aria-label", () => {
+    render(<TransactionReceipt data={mockReceipt} />);
+    expect(screen.getByRole("img", { name: /qr code/i })).toBeInTheDocument();
+  });
+
+  it("shows 'failed' status in red for failed transactions", () => {
+    render(<TransactionReceipt data={{ ...mockReceipt, status: "failed" }} />);
+    expect(screen.getByText("failed")).toBeInTheDocument();
+  });
+});

--- a/src/test/bank-validation.test.ts
+++ b/src/test/bank-validation.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateAccountNumber,
+  validateRoutingNumber,
+  validateIBAN,
+  validateBankField,
+} from "@/lib/bank-validation";
+
+describe("validateAccountNumber", () => {
+  it("rejects empty string", () => {
+    expect(validateAccountNumber("").valid).toBe(false);
+  });
+
+  it("rejects non-digit characters", () => {
+    expect(validateAccountNumber("123abc").valid).toBe(false);
+  });
+
+  it("rejects too short (< 4 digits)", () => {
+    expect(validateAccountNumber("123").valid).toBe(false);
+  });
+
+  it("rejects too long (> 20 digits)", () => {
+    expect(validateAccountNumber("123456789012345678901").valid).toBe(false);
+  });
+
+  it("accepts valid 10-digit account number", () => {
+    expect(validateAccountNumber("0123456789").valid).toBe(true);
+  });
+
+  it("accepts 4-digit minimum", () => {
+    expect(validateAccountNumber("1234").valid).toBe(true);
+  });
+});
+
+describe("validateRoutingNumber", () => {
+  it("rejects empty string", () => {
+    expect(validateRoutingNumber("").valid).toBe(false);
+  });
+
+  it("rejects non-9-digit input", () => {
+    expect(validateRoutingNumber("12345678").valid).toBe(false);
+    expect(validateRoutingNumber("1234567890").valid).toBe(false);
+  });
+
+  it("rejects 9 digits that fail ABA checksum", () => {
+    // 123456789: 3*(1+4+7) + 7*(2+5+8) + (3+6+9) = 36+105+18 = 159, not divisible by 10
+    expect(validateRoutingNumber("123456789").valid).toBe(false);
+  });
+
+  it("accepts a valid ABA routing number (021000021 — JPMorgan Chase)", () => {
+    expect(validateRoutingNumber("021000021").valid).toBe(true);
+  });
+
+  it("accepts 322271627 (Chase California)", () => {
+    expect(validateRoutingNumber("322271627").valid).toBe(true);
+  });
+});
+
+describe("validateIBAN", () => {
+  it("rejects empty string", () => {
+    expect(validateIBAN("").valid).toBe(false);
+  });
+
+  it("rejects malformed IBAN (no country code)", () => {
+    expect(validateIBAN("12345678901234").valid).toBe(false);
+  });
+
+  it("rejects IBAN with invalid check digits", () => {
+    expect(validateIBAN("GB00NWBK60161331926819").valid).toBe(false);
+  });
+
+  it("accepts valid GB IBAN", () => {
+    expect(validateIBAN("GB29NWBK60161331926819").valid).toBe(true);
+  });
+
+  it("accepts IBAN with spaces (normalised)", () => {
+    expect(validateIBAN("GB29 NWBK 6016 1331 9268 19").valid).toBe(true);
+  });
+
+  it("accepts valid DE IBAN", () => {
+    expect(validateIBAN("DE89370400440532013000").valid).toBe(true);
+  });
+});
+
+describe("validateBankField", () => {
+  it("delegates 'account' to validateAccountNumber", () => {
+    expect(validateBankField("account", "0123456789").valid).toBe(true);
+    expect(validateBankField("account", "").valid).toBe(false);
+  });
+
+  it("delegates 'routing' to validateRoutingNumber", () => {
+    expect(validateBankField("routing", "021000021").valid).toBe(true);
+    expect(validateBankField("routing", "123456789").valid).toBe(false);
+  });
+
+  it("delegates 'iban' to validateIBAN", () => {
+    expect(validateBankField("iban", "GB29NWBK60161331926819").valid).toBe(true);
+    expect(validateBankField("iban", "INVALID").valid).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

This PR integrates three new UI components into the offramp flow and adds comprehensive unit test coverage for all of them.
closes #258 
closes #259 
closes #260
---

## Changes

### 1. BankAccountInput → FormCard (e395e97)

Replaces the plain account number input with BankAccountInput.

- Three modes: Local (generic), US ABA (routing + account with ABA checksum), IBAN (MOD-97)
- Inline validation via bank-validation.ts with error/success states on blur
- Added bankMode, routingNumber, iban state to FormCard
- Account verification still triggered on accountNumber change

### 2. TransactionReceipt → TransactionProgressModal (83e75b8)

Shows a full receipt card on transaction success.

- Added optional receipt?: ReceiptData prop to TransactionProgressModalProps
- Renders TransactionReceipt when receipt is provided (amount, rate, fees, bank, masked account, QR placeholder, Print/Share)
- Falls back to tx hash + Stellar Explorer link when no receipt — fully backward compatible

### 3. QuoteComparison → FormCard (c24543a)

Multi-provider quote comparison table below the payout estimate.

- buildProviderQuotes() derives Paycrest, Yellow Card, Kotani Pay rows from the live quote with realistic offsets
- selectedProviderId state defaults to paycrest
- Renders below PayoutBox when quote is available; skeleton rows while loading
- Sortable by Best Rate / Lowest Fee / Fastest; selected row uses aria-pressed

### 4. Unit tests (41e1b9a)

52 tests across 4 new files, all passing:

| File | Tests |
|---|---|
| bank-validation.test.ts | 20 |
| BankAccountInput.test.tsx | 11 |
| QuoteComparison.test.tsx | 8 |
| TransactionReceipt.test.tsx | 13 |

Coverage: validation edge cases (ABA checksum, IBAN MOD-97), rendering, user interactions (tab switching, row selection, sort), accessibility (aria-pressed, aria-label, role=alert), conditional rendering.

---

## Testing

```bash
npm test -- src/test/bank-validation.test.ts src/test/BankAccountInput.test.tsx src/test/QuoteComparison.test.tsx src/test/TransactionReceipt.test.tsx
# 4 files, 52 tests, all passed
```

---

## Notes

- buildProviderQuotes uses mock offsets for Yellow Card and Kotani Pay — replace with real provider API calls in a follow-up
- receipt prop is optional; existing callers are unaffected
- Pre-existing failures in Header.test.tsx, page.test.tsx, TransactionProgressModal.test.tsx are unrelated to this PR