### PR TITLE
feat(api): add API versioning, database integration, and real-time updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,11 @@ SENTRY_AUTH_TOKEN=your_sentry_auth_token_here
 # Set to "true" to generate a bundle analysis report during build.
 ANALYZE=false
 
+# PostgreSQL connection string used by the server to connect to the database.
+# Format: postgresql://user:password@host:port/dbname
+# Example: postgresql://postgres:secret@localhost:5432/stellar_spend
+DATABASE_URL=postgresql://user:password@localhost:5432/dbname
+
 # Comma-separated list of origins allowed to call the API from a browser.
 # In production, set this to your actual frontend origin(s), e.g.:
 #   ALLOWED_ORIGINS=https://your-app.vercel.app,https://www.your-domain.com

--- a/docs/api-migration-v1.md
+++ b/docs/api-migration-v1.md
@@ -1,0 +1,116 @@
+# API Migration Guide: Unversioned → v1
+
+This guide covers the changes introduced by API versioning and how to update your integration.
+
+## Route Changes
+
+All routes now have a `/api/v1/` prefix. Unversioned routes continue to work during the transition period but are deprecated.
+
+| Legacy Route                                | Versioned Route                                |
+| ------------------------------------------- | ---------------------------------------------- |
+| `GET /api/health`                           | `GET /api/v1/health`                           |
+| `GET /api/fx-rates`                         | `GET /api/v1/fx-rates`                         |
+| `POST /api/offramp/quote`                   | `POST /api/v1/offramp/quote`                   |
+| `GET /api/offramp/rate`                     | `GET /api/v1/offramp/rate`                     |
+| `GET /api/offramp/currencies`               | `GET /api/v1/offramp/currencies`               |
+| `GET /api/offramp/verify-account`           | `GET /api/v1/offramp/verify-account`           |
+| `GET /api/offramp/institutions/[currency]`  | `GET /api/v1/offramp/institutions/[currency]`  |
+| `GET /api/offramp/status/[orderId]`         | `GET /api/v1/offramp/status/[orderId]`         |
+| `POST /api/offramp/paycrest/order`          | `POST /api/v1/offramp/paycrest/order`          |
+| `GET /api/offramp/paycrest/order/[orderId]` | `GET /api/v1/offramp/paycrest/order/[orderId]` |
+| `POST /api/offramp/bridge/build-tx`         | `POST /api/v1/offramp/bridge/build-tx`         |
+| `GET /api/offramp/bridge/gas-fee-options`   | `GET /api/v1/offramp/bridge/gas-fee-options`   |
+| `GET /api/offramp/bridge/status/[txHash]`   | `GET /api/v1/offramp/bridge/status/[txHash]`   |
+| `GET /api/offramp/bridge/tx-status/[hash]`  | `GET /api/v1/offramp/bridge/tx-status/[hash]`  |
+| `POST /api/offramp/bridge/submit-soroban`   | `POST /api/v1/offramp/bridge/submit-soroban`   |
+| `POST /api/webhooks/paycrest`               | `POST /api/v1/webhooks/paycrest`               |
+
+## Version Negotiation
+
+Three ways to specify the API version:
+
+**1. URL prefix (recommended)**
+
+```
+GET /api/v1/offramp/quote
+```
+
+**2. X-API-Version header**
+
+```
+GET /api/offramp/quote
+X-API-Version: 1
+```
+
+**3. Accept header**
+
+```
+GET /api/offramp/quote
+Accept: application/vnd.stellarspend.v1+json
+```
+
+URL prefix takes precedence over headers. Unversioned requests without headers default to v1.
+
+## Deprecation Timeline
+
+Legacy unversioned routes (`/api/*`) are deprecated as of **2025-01-01** and will be removed on **2026-01-01**.
+
+Deprecated routes return these response headers:
+
+```
+Deprecation: 2025-01-01
+Sunset: 2026-01-01
+Link: </api/v1/{path}>; rel="successor-version"
+```
+
+## Code Examples
+
+**Before:**
+
+```typescript
+const res = await fetch("/api/offramp/quote", {
+  method: "POST",
+  body: JSON.stringify({ amount, currency, feeMethod }),
+});
+```
+
+**After:**
+
+```typescript
+const res = await fetch("/api/v1/offramp/quote", {
+  method: "POST",
+  body: JSON.stringify({ amount, currency, feeMethod }),
+});
+```
+
+**Or using the header approach (no URL change needed):**
+
+```typescript
+const res = await fetch("/api/offramp/quote", {
+  method: "POST",
+  headers: { "X-API-Version": "1" },
+  body: JSON.stringify({ amount, currency, feeMethod }),
+});
+```
+
+## Version Discovery
+
+Query available versions programmatically:
+
+```
+GET /api/versions
+```
+
+Response:
+
+```json
+{
+  "versions": [
+    {
+      "version": "v1",
+      "status": "supported",
+      "prefix": "/api/v1"
+    }
+  ]
+}
+```

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from "next/server";
+import { registry } from "./src/lib/api-versioning/registry";
+
+// Matches /api/v{n}/... and captures the version segment
+const VERSIONED_PATH_RE = /^\/api\/(v\d+)(\/.*)?$/;
+
+// Matches /api/{non-version-segment}/... (unversioned legacy paths)
+const UNVERSIONED_API_RE = /^\/api\/(?!v\d+(?:\/|$))(.*)$/;
+
+// Matches application/vnd.stellarspend.v{n}+json
+const ACCEPT_HEADER_RE = /application\/vnd\.stellarspend\.(v\d+)\+json/;
+
+// Migration guide URL referenced in deprecation headers
+const MIGRATION_GUIDE_URL = "/docs/api-migration-v1";
+
+function resolveVersionFromHeaders(request: NextRequest): string | null {
+    // X-API-Version header takes precedence over Accept header
+    const xApiVersion = request.headers.get("x-api-version");
+    if (xApiVersion && xApiVersion.trim() !== "") {
+        const normalised = /^\d+$/.test(xApiVersion.trim())
+            ? `v${xApiVersion.trim()}`
+            : xApiVersion.trim();
+        return normalised;
+    }
+
+    // Accept header
+    const accept = request.headers.get("accept");
+    if (accept) {
+        const match = ACCEPT_HEADER_RE.exec(accept);
+        if (match) {
+            return match[1];
+        }
+    }
+
+    return null;
+}
+
+function addLegacyDeprecationHeaders(response: NextResponse, legacyPath: string): NextResponse {
+    // v1 is currently supported, so legacy routes are deprecated (pointing to v1 successor)
+    // Use a fixed deprecation date — when v1 was introduced
+    response.headers.set("Deprecation", "2025-01-01");
+    response.headers.set("Sunset", "2026-01-01");
+    response.headers.set(
+        "Link",
+        `</api/v1/${legacyPath.replace(/^\//, "")}>; rel="successor-version", <${MIGRATION_GUIDE_URL}>; rel="deprecation"`
+    );
+    return response;
+}
+
+export function middleware(request: NextRequest): NextResponse {
+    const { pathname } = request.nextUrl;
+
+    // 1. Check for versioned URL path: /api/v{n}/*
+    const versionedMatch = VERSIONED_PATH_RE.exec(pathname);
+    if (versionedMatch) {
+        const version = versionedMatch[1];
+        if (!registry.isKnown(version)) {
+            return NextResponse.json(
+                { error: "API version not supported" },
+                { status: 404 }
+            );
+        }
+        // Known version — pass through, add X-API-Version header
+        const response = NextResponse.next();
+        response.headers.set("X-API-Version", version.replace(/^v/, ""));
+        return response;
+    }
+
+    // 2. Check for unversioned /api/* paths with version headers
+    const unversionedMatch = UNVERSIONED_API_RE.exec(pathname);
+    if (unversionedMatch) {
+        const subpath = unversionedMatch[1] ?? "";
+        const version = resolveVersionFromHeaders(request);
+        if (version !== null) {
+            if (!registry.isKnown(version)) {
+                const supported = registry.getAll().map((e) => e.version);
+                return NextResponse.json(
+                    { error: "Unsupported API version", supported },
+                    { status: 400 }
+                );
+            }
+            // Rewrite URL to versioned equivalent
+            const url = request.nextUrl.clone();
+            url.pathname = `/api/${version}/${subpath}`;
+            return NextResponse.rewrite(url);
+        }
+
+        // Legacy route with no version headers — add deprecation headers
+        const response = NextResponse.next();
+        addLegacyDeprecationHeaders(response, subpath);
+        return response;
+    }
+
+    // 3. Pass through all other requests unchanged
+    return NextResponse.next();
+}
+
+export const config = {
+    matcher: ["/api/:path*"],
+};

--- a/migrations/001_create_transactions.sql
+++ b/migrations/001_create_transactions.sql
@@ -1,0 +1,28 @@
+-- Migration: 001_create_transactions
+-- Creates the transactions table and supporting indexes.
+-- Idempotent: safe to run multiple times (uses IF NOT EXISTS).
+
+CREATE TABLE IF NOT EXISTS transactions (
+  id                              TEXT PRIMARY KEY,
+  timestamp                       BIGINT NOT NULL,
+  user_address                    TEXT NOT NULL,
+  amount                          TEXT NOT NULL,
+  currency                        TEXT NOT NULL,
+  stellar_tx_hash                 TEXT,
+  bridge_status                   TEXT,
+  payout_order_id                 TEXT,
+  payout_status                   TEXT,
+  beneficiary_institution         TEXT NOT NULL,
+  beneficiary_account_identifier  TEXT NOT NULL,
+  beneficiary_account_name        TEXT NOT NULL,
+  beneficiary_currency            TEXT NOT NULL,
+  status                          TEXT NOT NULL,
+  error                           TEXT,
+  CONSTRAINT transactions_status_check CHECK (status IN ('pending', 'completed', 'failed'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_transactions_user_address_timestamp
+  ON transactions (user_address, timestamp DESC);
+
+CREATE INDEX IF NOT EXISTS idx_transactions_payout_order_id
+  ON transactions (payout_order_id);

--- a/src/app/api/offramp/bridge/status/[txHash]/route.ts
+++ b/src/app/api/offramp/bridge/status/[txHash]/route.ts
@@ -1,19 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { env } from '@/lib/env';
 import { extractErrorMessage } from '@/lib/offramp/utils/errors';
+import { get, set, isFresh } from '@/lib/polling/status-cache';
 import type { BridgeStatus } from '@/lib/offramp/types';
+
+const BRIDGE_TERMINAL_STATES: BridgeStatus[] = ['completed', 'failed', 'expired'];
 
 /**
  * GET /api/offramp/bridge/status/[txHash]
- * 
+ *
  * Polls the Allbridge bridge transfer status.
- * 
+ * Checks server-side cache before calling Allbridge; returns stale cache + upstreamError on failure.
+ *
  * Response:
  * {
  *   data: {
  *     status: BridgeStatus
  *     txHash: string
  *     receiveAmount?: string
+ *     cachedAt?: number
+ *     upstreamError?: string
  *   }
  * }
  */
@@ -22,6 +28,20 @@ export async function GET(
   { params }: { params: Promise<{ txHash: string }> }
 ) {
   const { txHash } = await params;
+
+  // Check cache first
+  const cached = get(txHash);
+  if (cached && isFresh(cached)) {
+    const raw = cached.raw as { receiveAmount?: string };
+    return NextResponse.json({
+      data: {
+        status: cached.status as BridgeStatus,
+        txHash,
+        receiveAmount: raw?.receiveAmount,
+        cachedAt: cached.cachedAt,
+      },
+    });
+  }
 
   try {
     // Initialize Allbridge SDK
@@ -37,13 +57,33 @@ export async function GET(
       // Handle 404 gracefully - return pending status
       const message = extractErrorMessage(error);
       if (message.includes('404') || message.includes('not found')) {
+        const status: BridgeStatus = 'pending';
+        const entry = {
+          status,
+          raw: { receiveAmount: undefined },
+          cachedAt: Date.now(),
+          isTerminal: false,
+        };
+        set(txHash, entry);
+        return NextResponse.json({
+          data: { status, txHash },
+        });
+      }
+
+      // Upstream error — return stale cache if available
+      if (cached) {
+        const raw = cached.raw as { receiveAmount?: string };
         return NextResponse.json({
           data: {
-            status: 'pending' as BridgeStatus,
+            status: cached.status as BridgeStatus,
             txHash,
+            receiveAmount: raw?.receiveAmount,
+            cachedAt: cached.cachedAt,
+            upstreamError: message || 'Failed to fetch bridge status',
           },
         });
       }
+
       throw error;
     }
 
@@ -62,6 +102,17 @@ export async function GET(
       }
     }
 
+    const isTerminal = BRIDGE_TERMINAL_STATES.includes(status);
+    const raw = { receiveAmount: transferStatus?.receiveAmount };
+
+    // Populate cache
+    set(txHash, {
+      status,
+      raw,
+      cachedAt: Date.now(),
+      isTerminal,
+    });
+
     return NextResponse.json({
       data: {
         status,
@@ -72,6 +123,21 @@ export async function GET(
   } catch (error) {
     console.error('Bridge status error:', error);
     const message = extractErrorMessage(error);
+
+    // Return stale cache entry with upstreamError if available
+    if (cached) {
+      const raw = cached.raw as { receiveAmount?: string };
+      return NextResponse.json({
+        data: {
+          status: cached.status as BridgeStatus,
+          txHash,
+          receiveAmount: raw?.receiveAmount,
+          cachedAt: cached.cachedAt,
+          upstreamError: message || 'Failed to fetch bridge status',
+        },
+      });
+    }
+
     return NextResponse.json(
       { error: message || 'Failed to fetch bridge status' },
       { status: 500 }

--- a/src/app/api/offramp/execute-payout/route.ts
+++ b/src/app/api/offramp/execute-payout/route.ts
@@ -1,6 +1,49 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { v4 as uuidv4 } from 'uuid';
+import { dal } from '@/lib/db/dal';
+import type { Transaction } from '@/lib/transaction-storage';
 
-// TODO: execute payout via Base USDC transfer + Paycrest order
-export async function POST() {
-  return NextResponse.json({ error: 'Not implemented' }, { status: 501 });
+export async function POST(request: NextRequest) {
+  let body: Partial<Transaction> & { userAddress?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid request body' }, { status: 400 });
+  }
+
+  const {
+    userAddress,
+    amount,
+    currency,
+    beneficiary,
+  } = body as {
+    userAddress?: string;
+    amount?: string;
+    currency?: string;
+    beneficiary?: Transaction['beneficiary'];
+  };
+
+  if (!userAddress || !amount || !currency || !beneficiary) {
+    return NextResponse.json({ error: 'missing required fields' }, { status: 400 });
+  }
+
+  const id = uuidv4();
+  const transaction: Transaction = {
+    id,
+    timestamp: Date.now(),
+    userAddress,
+    amount,
+    currency,
+    beneficiary,
+    status: 'pending',
+  };
+
+  try {
+    await dal.save(transaction);
+  } catch {
+    return NextResponse.json({ error: 'internal server error' }, { status: 500 });
+  }
+
+  // TODO: proceed with bridge/payout calls using the saved transaction id
+  return NextResponse.json({ id, status: 'pending' }, { status: 200 });
 }

--- a/src/app/api/offramp/status/[orderId]/route.ts
+++ b/src/app/api/offramp/status/[orderId]/route.ts
@@ -1,12 +1,25 @@
 import { NextResponse } from 'next/server';
 import { env } from '@/lib/env';
+import { get, set, isFresh } from '@/lib/polling/status-cache';
 
 export const maxDuration = 10;
 
 const PAYCREST_BASE_URL = 'https://api.paycrest.io/v1';
 
+const PAYOUT_TERMINAL_STATES = ['validated', 'settled', 'refunded', 'expired'];
+
 export async function GET(_req: Request, { params }: { params: Promise<{ orderId: string }> }) {
   const { orderId } = await params;
+
+  // Check cache first
+  const cached = get(orderId);
+  if (cached && isFresh(cached)) {
+    return NextResponse.json({
+      status: cached.status,
+      id: orderId,
+      cachedAt: cached.cachedAt,
+    });
+  }
 
   try {
     const res = await fetch(`${PAYCREST_BASE_URL}/sender/orders/${orderId}`, {
@@ -19,16 +32,50 @@ export async function GET(_req: Request, { params }: { params: Promise<{ orderId
 
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
+      const errorMessage = body.message ?? 'Failed to fetch order status';
+
+      // Return stale cache entry with upstreamError if available
+      if (cached) {
+        return NextResponse.json({
+          status: cached.status,
+          id: orderId,
+          cachedAt: cached.cachedAt,
+          upstreamError: errorMessage,
+        });
+      }
+
       return NextResponse.json(
-        { error: body.message ?? 'Failed to fetch order status' },
+        { error: errorMessage },
         { status: res.status }
       );
     }
 
     const data = await res.json();
-    return NextResponse.json({ status: data.status, id: orderId });
+    const status: string = data.status;
+    const isTerminal = PAYOUT_TERMINAL_STATES.includes(status);
+
+    // Populate cache
+    set(orderId, {
+      status,
+      raw: data,
+      cachedAt: Date.now(),
+      isTerminal,
+    });
+
+    return NextResponse.json({ status, id: orderId });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Internal server error';
+
+    // Return stale cache entry with upstreamError if available
+    if (cached) {
+      return NextResponse.json({
+        status: cached.status,
+        id: orderId,
+        cachedAt: cached.cachedAt,
+        upstreamError: message,
+      });
+    }
+
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/api/offramp/ws/[id]/route.ts
+++ b/src/app/api/offramp/ws/[id]/route.ts
@@ -1,0 +1,34 @@
+/**
+ * WebSocket upgrade endpoint for transaction status push.
+ *
+ * Next.js App Router does not natively support WebSocket upgrades in route
+ * handlers. This route returns 501 Not Implemented when accessed via a
+ * standard HTTP request.
+ *
+ * To enable WebSocket support, use a custom Node.js server that intercepts
+ * the HTTP upgrade event and calls the utilities exported from
+ * `src/lib/polling/ws-server.ts` directly.
+ *
+ * Example (custom server):
+ *   import { onConnect } from '@/lib/polling/ws-server';
+ *   server.on('upgrade', (req, socket, head) => {
+ *     const id = extractIdFromUrl(req.url);
+ *     wss.handleUpgrade(req, socket, head, (ws) => onConnect(id, ws as unknown as WebSocket));
+ *   });
+ */
+
+export { onConnect, broadcast, closeForId } from '@/lib/polling/ws-server';
+export type { StatusPush } from '@/lib/polling/ws-server';
+
+export async function GET(): Promise<Response> {
+    return new Response(
+        JSON.stringify({
+            error: 'WebSocket upgrade not supported in Next.js App Router route handlers.',
+            hint: 'Use a custom Node.js server and import { onConnect, broadcast, closeForId } from @/lib/polling/ws-server.',
+        }),
+        {
+            status: 501,
+            headers: { 'Content-Type': 'application/json' },
+        },
+    );
+}

--- a/src/app/api/transactions/[id]/route.ts
+++ b/src/app/api/transactions/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { dal, DatabaseError } from '@/lib/db/dal';
+import { ErrorHandler } from '@/lib/error-handler';
+
+export async function PATCH(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    const { id } = await params;
+
+    let body: Record<string, unknown>;
+    try {
+        body = await request.json();
+    } catch {
+        return ErrorHandler.validation('Invalid JSON body');
+    }
+
+    try {
+        const existing = await dal.getById(id);
+        if (!existing) {
+            return ErrorHandler.notFound('transaction');
+        }
+
+        await dal.update(id, body);
+
+        const updated = await dal.getById(id);
+        return NextResponse.json(updated, { status: 200 });
+    } catch (err) {
+        if (err instanceof DatabaseError) {
+            return ErrorHandler.serverError(err);
+        }
+        return ErrorHandler.serverError(err);
+    }
+}

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { dal, DatabaseError } from '@/lib/db/dal';
+import { ErrorHandler } from '@/lib/error-handler';
+import type { Transaction } from '@/lib/transaction-storage';
+
+const REQUIRED_FIELDS: (keyof Transaction)[] = [
+    'id',
+    'timestamp',
+    'userAddress',
+    'amount',
+    'currency',
+    'beneficiary',
+    'status',
+];
+
+const REQUIRED_BENEFICIARY_FIELDS = [
+    'institution',
+    'accountIdentifier',
+    'accountName',
+    'currency',
+] as const;
+
+export async function GET(request: NextRequest) {
+    const wallet = request.nextUrl.searchParams.get('wallet');
+
+    if (!wallet) {
+        return ErrorHandler.validation('wallet address is required');
+    }
+
+    try {
+        const transactions = await dal.getByUser(wallet);
+        return NextResponse.json(transactions, { status: 200 });
+    } catch (err) {
+        if (err instanceof DatabaseError) {
+            return ErrorHandler.serverError(err);
+        }
+        return ErrorHandler.serverError(err);
+    }
+}
+
+export async function POST(request: NextRequest) {
+    let body: Record<string, unknown>;
+    try {
+        body = await request.json();
+    } catch {
+        return ErrorHandler.validation('Invalid JSON body');
+    }
+
+    for (const field of REQUIRED_FIELDS) {
+        if (body[field] === undefined || body[field] === null) {
+            return ErrorHandler.validation(`Missing required field: ${field}`);
+        }
+    }
+
+    const beneficiary = body.beneficiary as Record<string, unknown> | undefined;
+    if (!beneficiary || typeof beneficiary !== 'object') {
+        return ErrorHandler.validation('Missing required field: beneficiary');
+    }
+
+    for (const field of REQUIRED_BENEFICIARY_FIELDS) {
+        if (!beneficiary[field]) {
+            return ErrorHandler.validation(`Missing required beneficiary field: ${field}`);
+        }
+    }
+
+    const transaction = body as unknown as Transaction;
+
+    try {
+        await dal.save(transaction);
+        return NextResponse.json(transaction, { status: 201 });
+    } catch (err) {
+        if (err instanceof DatabaseError) {
+            return ErrorHandler.serverError(err);
+        }
+        return ErrorHandler.serverError(err);
+    }
+}

--- a/src/app/api/v1/fx-rates/route.ts
+++ b/src/app/api/v1/fx-rates/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '@/app/api/fx-rates/route';

--- a/src/app/api/v1/health/route.ts
+++ b/src/app/api/v1/health/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '@/app/api/health/route';

--- a/src/app/api/v1/offramp/bridge/build-tx/route.ts
+++ b/src/app/api/v1/offramp/bridge/build-tx/route.ts
@@ -1,0 +1,1 @@
+export { POST } from '@/app/api/offramp/bridge/build-tx/route';

--- a/src/app/api/v1/offramp/bridge/gas-fee-options/route.ts
+++ b/src/app/api/v1/offramp/bridge/gas-fee-options/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '@/app/api/offramp/bridge/gas-fee-options/route';

--- a/src/app/api/v1/offramp/bridge/status/[txHash]/route.ts
+++ b/src/app/api/v1/offramp/bridge/status/[txHash]/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '@/app/api/offramp/bridge/status/[txHash]/route';

--- a/src/app/api/v1/offramp/bridge/submit-soroban/route.ts
+++ b/src/app/api/v1/offramp/bridge/submit-soroban/route.ts
@@ -1,0 +1,1 @@
+export { POST } from '@/app/api/offramp/bridge/submit-soroban/route';

--- a/src/app/api/v1/offramp/bridge/tx-status/[hash]/route.ts
+++ b/src/app/api/v1/offramp/bridge/tx-status/[hash]/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '@/app/api/offramp/bridge/tx-status/[hash]/route';

--- a/src/app/api/v1/offramp/currencies/route.ts
+++ b/src/app/api/v1/offramp/currencies/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '@/app/api/offramp/currencies/route';

--- a/src/app/api/v1/offramp/institutions/[currency]/route.ts
+++ b/src/app/api/v1/offramp/institutions/[currency]/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '@/app/api/offramp/institutions/[currency]/route';

--- a/src/app/api/v1/offramp/paycrest/order/[orderId]/route.ts
+++ b/src/app/api/v1/offramp/paycrest/order/[orderId]/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '@/app/api/offramp/paycrest/order/[orderId]/route';

--- a/src/app/api/v1/offramp/paycrest/order/route.ts
+++ b/src/app/api/v1/offramp/paycrest/order/route.ts
@@ -1,0 +1,1 @@
+export { POST } from '@/app/api/offramp/paycrest/order/route';

--- a/src/app/api/v1/offramp/quote/route.ts
+++ b/src/app/api/v1/offramp/quote/route.ts
@@ -1,0 +1,1 @@
+export { POST } from '@/app/api/offramp/quote/route';

--- a/src/app/api/v1/offramp/rate/route.ts
+++ b/src/app/api/v1/offramp/rate/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '@/app/api/offramp/rate/route';

--- a/src/app/api/v1/offramp/status/[orderId]/route.ts
+++ b/src/app/api/v1/offramp/status/[orderId]/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '@/app/api/offramp/status/[orderId]/route';

--- a/src/app/api/v1/offramp/verify-account/route.ts
+++ b/src/app/api/v1/offramp/verify-account/route.ts
@@ -1,0 +1,1 @@
+export { POST } from '@/app/api/offramp/verify-account/route';

--- a/src/app/api/v1/webhooks/paycrest/route.ts
+++ b/src/app/api/v1/webhooks/paycrest/route.ts
@@ -1,0 +1,1 @@
+export { POST } from '@/app/api/webhooks/paycrest/route';

--- a/src/app/api/versions/route.ts
+++ b/src/app/api/versions/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { registry } from "@/lib/api-versioning/registry";
+
+export async function GET() {
+    const versions = registry.getAll().map((entry) => {
+        const v: Record<string, unknown> = {
+            version: entry.version,
+            status: entry.status,
+            prefix: entry.prefix,
+        };
+        if (entry.deprecatedAt) v.deprecatedAt = entry.deprecatedAt;
+        if (entry.sunsetAt) v.sunsetAt = entry.sunsetAt;
+        return v;
+    });
+
+    const response = NextResponse.json({ versions }, { status: 200 });
+    // Strip leading 'v' for the numeric header value (e.g. 'v1' → '1')
+    response.headers.set("X-API-Version", "1");
+    return response;
+}

--- a/src/app/api/webhooks/paycrest/route.ts
+++ b/src/app/api/webhooks/paycrest/route.ts
@@ -5,6 +5,18 @@ import { ErrorHandler } from '@/lib/error-handler';
 import { generateRequestId, createRequestLogger } from '@/lib/offramp/utils/logger';
 import type { PayoutStatus } from '@/lib/offramp/types';
 import { mapPaycrestStatus } from '@/lib/offramp/utils/mapPaycrestStatus';
+import { dal, DatabaseError } from '@/lib/db/dal';
+import { enqueue } from '@/lib/webhook/dispatcher';
+
+const SENSITIVE_HEADERS = new Set(['authorization', 'x-paycrest-signature']);
+
+function redactHeaders(headers: Headers): Record<string, string> {
+  const result: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    result[key] = SENSITIVE_HEADERS.has(key.toLowerCase()) ? '[REDACTED]' : value;
+  });
+  return result;
+}
 
 export const maxDuration = 10;
 
@@ -41,6 +53,18 @@ export async function POST(request: Request) {
     return ErrorHandler.unauthorized('Invalid signature');
   }
 
+  // Enqueue for retry tracking — fire-and-forget, does not block the response
+  enqueue(
+    {
+      headers: redactHeaders(request.headers),
+      body: rawBody,
+      source: 'paycrest',
+    },
+    '/api/webhooks/paycrest/process',
+  ).catch((err) => {
+    console.error(JSON.stringify({ requestId, event: 'webhook.enqueue_failed', error: err instanceof Error ? err.message : String(err) }));
+  });
+
   try {
     const payload = JSON.parse(rawBody);
     const eventType: string = payload?.event ?? '';
@@ -49,13 +73,28 @@ export async function POST(request: Request) {
 
     console.log(JSON.stringify({ requestId, eventType, orderId, status }));
 
-    if (eventType !== 'payment_order.settled' && eventType !== 'payment_order.pending') {
+    const transaction = await dal.getByPayoutOrderId(orderId);
+    if (!transaction) {
+      console.warn(JSON.stringify({ requestId, message: 'No transaction found for orderId', orderId }));
+      logger.logSuccess(200);
+      return NextResponse.json({ received: true });
+    }
+
+    if (eventType === 'payment_order.settled') {
+      await dal.update(transaction.id, { status: 'completed', payoutStatus: 'settled' });
+    } else if (eventType === 'payment_order.pending') {
+      await dal.update(transaction.id, { payoutStatus: 'pending' });
+    } else {
       console.warn(`unhandled event type: ${eventType}`);
     }
 
     logger.logSuccess(200);
     return NextResponse.json({ received: true });
-  } catch {
+  } catch (err) {
+    if (err instanceof DatabaseError) {
+      logger.logError(500, err.message);
+      return ErrorHandler.serverError(err);
+    }
     logger.logError(400, 'Failed to parse webhook payload');
     return ErrorHandler.validation('Malformed JSON payload');
   }

--- a/src/app/api/webhooks/retry-runner/route.ts
+++ b/src/app/api/webhooks/retry-runner/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse } from "next/server";
+import { getDueRecords, updateRecord } from "@/lib/webhook/delivery-store";
+import * as dispatcher from "@/lib/webhook/dispatcher";
+import * as dlq from "@/lib/webhook/dlq";
+import * as alertService from "@/lib/webhook/alert-service";
+import { scheduleNext, hasRemainingAttempts } from "@/lib/webhook/retry-scheduler";
+import type { DeliveryRecord } from "@/lib/webhook/types";
+
+interface RecordResult {
+    id: string;
+    outcome: "delivered" | "retryScheduled" | "failed";
+    attemptCount: number;
+    error?: string;
+}
+
+/**
+ * Processes a single due delivery record sequentially.
+ * Prevents concurrent delivery of the same record (Requirement 1.4) by
+ * processing records one at a time in a sequential loop.
+ */
+async function processRecord(record: DeliveryRecord): Promise<RecordResult> {
+    const result = await dispatcher.attempt(record);
+
+    if (result.success) {
+        await dispatcher.markDelivered(record.id, record.attemptCount + 1);
+        return { id: record.id, outcome: "delivered", attemptCount: record.attemptCount + 1 };
+    }
+
+    // Failure path: check if retryable and has remaining attempts
+    const updatedRecord: DeliveryRecord = {
+        ...record,
+        attemptCount: record.attemptCount + 1,
+    };
+
+    if (result.retryable && hasRemainingAttempts(updatedRecord)) {
+        const scheduled = await scheduleNext(updatedRecord);
+        await updateRecord(record.id, {
+            nextAttemptAt: scheduled.nextAttemptAt,
+            attemptCount: updatedRecord.attemptCount,
+        });
+        return { id: record.id, outcome: "retryScheduled", attemptCount: updatedRecord.attemptCount };
+    }
+
+    // Non-retryable or max attempts reached
+    await dispatcher.markFailed(updatedRecord);
+    const dlqEntry = await dlq.write(updatedRecord);
+    await alertService.notify(dlqEntry);
+
+    return {
+        id: record.id,
+        outcome: "failed",
+        attemptCount: updatedRecord.attemptCount,
+        error: result.errorType ?? `HTTP ${result.httpStatus}`,
+    };
+}
+
+async function runRetries() {
+    const dueRecords = await getDueRecords();
+
+    const results: RecordResult[] = [];
+
+    // Process sequentially to prevent concurrent delivery of the same record (Requirement 1.4)
+    for (const record of dueRecords) {
+        try {
+            const result = await processRecord(record);
+            results.push(result);
+        } catch (err) {
+            results.push({
+                id: record.id,
+                outcome: "failed",
+                attemptCount: record.attemptCount,
+                error: err instanceof Error ? err.message : String(err),
+            });
+        }
+    }
+
+    return {
+        processed: results.length,
+        delivered: results.filter((r) => r.outcome === "delivered").length,
+        retryScheduled: results.filter((r) => r.outcome === "retryScheduled").length,
+        failed: results.filter((r) => r.outcome === "failed").length,
+        records: results,
+    };
+}
+
+export async function GET() {
+    try {
+        const summary = await runRetries();
+        return NextResponse.json({ ok: true, ...summary });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return NextResponse.json({ ok: false, error: message }, { status: 500 });
+    }
+}
+
+export async function POST() {
+    try {
+        const summary = await runRetries();
+        return NextResponse.json({ ok: true, ...summary });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return NextResponse.json({ ok: false, error: message }, { status: 500 });
+    }
+}

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { TransactionStorage, type Transaction } from "@/lib/transaction-storage";
+import type { Transaction } from "@/lib/transaction-storage";
 import { useStellarWallet } from "@/hooks/useStellarWallet";
 import { Header } from "@/components/Header";
 import { CopyButton } from "@/components/CopyButton";
 import { cn } from "@/lib/cn";
 import { getCurrencyFlag } from "@/lib/currency-flags";
+import { TransactionTableSkeleton } from "@/components/skeletons";
+import ExportControls from "@/components/ExportControls";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -29,8 +31,13 @@ function truncateTxHash(hash: string): string {
 
 function getCurrencySymbol(currency: string): string {
   const symbols: Record<string, string> = {
-    NGN: "₦", USD: "$", EUR: "€", GBP: "£",
-    KES: "KSh", GHS: "₵", ZAR: "R",
+    NGN: "₦",
+    USD: "$",
+    EUR: "€",
+    GBP: "£",
+    KES: "KSh",
+    GHS: "₵",
+    ZAR: "R",
   };
   return symbols[currency.toUpperCase()] || currency.toUpperCase();
 }
@@ -42,7 +49,12 @@ function StatusBadge({ status }: { status: Transaction["status"] }) {
     failed: "bg-red-500/20 text-red-500 border-red-500/30",
   };
   return (
-    <span className={cn("inline-block px-2.5 py-0.5 text-[10px] tracking-widest uppercase font-semibold border", styles[status])}>
+    <span
+      className={cn(
+        "inline-block px-2.5 py-0.5 text-[10px] tracking-widest uppercase font-semibold border",
+        styles[status],
+      )}
+    >
       {status}
     </span>
   );
@@ -82,16 +94,50 @@ const DEFAULT_FILTERS: Filters = {
 // ---------------------------------------------------------------------------
 
 export default function HistoryPage() {
-  const { wallet, isConnected, isConnecting, connect, disconnect } = useStellarWallet();
+  const { wallet, isConnected, isConnecting, connect, disconnect } =
+    useStellarWallet();
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (wallet?.publicKey) {
-      setTransactions(TransactionStorage.getByUser(wallet.publicKey));
-    } else {
+    if (!wallet?.publicKey) {
       setTransactions([]);
+      setError(null);
+      return;
     }
+
+    const address = wallet.publicKey;
+    setIsLoading(true);
+    setError(null);
+
+    fetch(`/api/transactions?wallet=${encodeURIComponent(address)}`)
+      .then((res) => {
+        if (!res.ok) {
+          return res.json().then(
+            (body) => {
+              throw new Error(body?.error ?? "Failed to load transactions");
+            },
+            () => {
+              throw new Error("Failed to load transactions");
+            },
+          );
+        }
+        return res.json() as Promise<Transaction[]>;
+      })
+      .then((data) => {
+        setTransactions(data);
+      })
+      .catch((err: unknown) => {
+        setError(
+          err instanceof Error ? err.message : "Failed to load transactions",
+        );
+        setTransactions([]);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
   }, [wallet?.publicKey]);
 
   const set = <K extends keyof Filters>(key: K, value: Filters[K]) =>
@@ -101,7 +147,8 @@ export default function HistoryPage() {
     setFilters((prev) => ({
       ...prev,
       sortField: field,
-      sortDir: prev.sortField === field && prev.sortDir === "desc" ? "asc" : "desc",
+      sortDir:
+        prev.sortField === field && prev.sortDir === "desc" ? "asc" : "desc",
     }));
 
   const filtered = useMemo(() => {
@@ -113,7 +160,7 @@ export default function HistoryPage() {
       result = result.filter(
         (tx) =>
           tx.id.toLowerCase().includes(q) ||
-          (tx.stellarTxHash?.toLowerCase().includes(q) ?? false)
+          (tx.stellarTxHash?.toLowerCase().includes(q) ?? false),
       );
     }
 
@@ -136,11 +183,13 @@ export default function HistoryPage() {
     // Amount range
     if (filters.amountMin !== "") {
       const min = parseFloat(filters.amountMin);
-      if (!isNaN(min)) result = result.filter((tx) => parseFloat(tx.amount) >= min);
+      if (!isNaN(min))
+        result = result.filter((tx) => parseFloat(tx.amount) >= min);
     }
     if (filters.amountMax !== "") {
       const max = parseFloat(filters.amountMax);
-      if (!isNaN(max)) result = result.filter((tx) => parseFloat(tx.amount) <= max);
+      if (!isNaN(max))
+        result = result.filter((tx) => parseFloat(tx.amount) <= max);
     }
 
     // Sort
@@ -163,8 +212,11 @@ export default function HistoryPage() {
     filters.amountMax;
 
   const SortIcon = ({ field }: { field: SortField }) => {
-    if (filters.sortField !== field) return <span className="ml-1 opacity-30">↕</span>;
-    return <span className="ml-1">{filters.sortDir === "asc" ? "↑" : "↓"}</span>;
+    if (filters.sortField !== field)
+      return <span className="ml-1 opacity-30">↕</span>;
+    return (
+      <span className="ml-1">{filters.sortDir === "asc" ? "↑" : "↓"}</span>
+    );
   };
 
   return (
@@ -196,7 +248,7 @@ export default function HistoryPage() {
             className={cn(
               "self-start sm:self-auto text-[10px] tracking-widest uppercase text-[#c9a962] border border-[#c9a962] px-4 py-2 min-h-[44px] flex items-center",
               "hover:bg-[#c9a962] hover:text-[#0a0a0a] transition-colors duration-150",
-              "focus:outline-none focus-visible:ring-1 focus-visible:ring-[#c9a962]"
+              "focus:outline-none focus-visible:ring-1 focus-visible:ring-[#c9a962]",
             )}
           >
             ← Back to Dashboard
@@ -214,37 +266,144 @@ export default function HistoryPage() {
                 "px-6 py-3 min-h-[44px] text-xs tracking-widest border border-[#c9a962]",
                 "text-[#c9a962] bg-transparent transition-colors duration-150",
                 "hover:bg-[#c9a962] hover:text-[#0a0a0a]",
-                "focus:outline-none focus-visible:ring-2 focus-visible:ring-[#c9a962]"
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-[#c9a962]",
               )}
             >
               CONNECT WALLET
             </button>
           </div>
+        ) : isLoading ? (
+          <TransactionTableSkeleton rows={5} />
+        ) : error ? (
+          <div
+            role="alert"
+            className="border border-red-500/30 bg-red-500/10 p-6 text-center"
+          >
+            <p className="text-sm text-red-400">{error}</p>
+          </div>
         ) : (
           <>
-            <ExportControls transactions={transactions} walletAddress={wallet?.publicKey} />
-            <div className="border border-[#333333] bg-[#111111] overflow-x-auto mt-4">
-            <table className="w-full min-w-[800px] border-collapse">
-              <thead>
-                <tr className="bg-[#c9a962]">
-                  {["DATE", "TX HASH", "AMOUNT", "CURRENCY", "BANK", "STATUS"].map((col) => (
-                    <th
-                      key={col}
-                      className="px-5 py-2.5 text-left text-[10px] tracking-[0.18em] font-semibold text-[#0a0a0a] uppercase whitespace-nowrap"
-                    >
-                      {col}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {transactions.map((tx, i) => (
-                  <tr
-                    key={tx.id}
+            <ExportControls
+              transactions={transactions}
+              walletAddress={wallet?.publicKey}
+            />
+
+            {/* ── Filters ── */}
+            <div className="border border-[#333333] bg-[#111111] p-4 mt-4">
+              <div className="flex flex-wrap gap-3 items-end">
+                {/* Search */}
+                <div className="flex flex-col gap-1">
+                  <label className="text-[10px] text-[#777777] uppercase tracking-widest">
+                    Search
+                  </label>
+                  <input
+                    type="text"
+                    value={filters.search}
+                    onChange={(e) => set("search", e.target.value)}
+                    placeholder="TX hash or ID"
+                    aria-label="Search transactions"
+                    className={cn(
+                      "w-48 bg-[#0a0a0a] border border-[#333333] px-3 py-2",
+                      "text-xs text-white placeholder-[#555555]",
+                      "focus:outline-none focus:border-[#c9a962]",
+                    )}
+                  />
+                </div>
+
+                {/* Status */}
+                <div className="flex flex-col gap-1">
+                  <label className="text-[10px] text-[#777777] uppercase tracking-widest">
+                    Status
+                  </label>
+                  <select
+                    value={filters.status}
+                    onChange={(e) =>
+                      set("status", e.target.value as Filters["status"])
+                    }
+                    aria-label="Filter by status"
+                    className={cn(
+                      "bg-[#0a0a0a] border border-[#333333] px-3 py-2",
+                      "text-xs text-white",
+                      "focus:outline-none focus:border-[#c9a962]",
+                    )}
+                  >
+                    <option value="all">All</option>
+                    <option value="pending">Pending</option>
+                    <option value="completed">Completed</option>
+                    <option value="failed">Failed</option>
+                  </select>
+                </div>
+
+                {/* Date from */}
+                <div className="flex flex-col gap-1">
+                  <label className="text-[10px] text-[#777777] uppercase tracking-widest">
+                    From
+                  </label>
+                  <input
+                    type="date"
+                    value={filters.dateFrom}
+                    onChange={(e) => set("dateFrom", e.target.value)}
+                    aria-label="Filter from date"
+                    className={cn(
+                      "bg-[#0a0a0a] border border-[#333333] px-3 py-2",
+                      "text-xs text-white [color-scheme:dark]",
+                      "focus:outline-none focus:border-[#c9a962]",
+                    )}
+                  />
+                </div>
+
+                {/* Date to */}
+                <div className="flex flex-col gap-1">
+                  <label className="text-[10px] text-[#777777] uppercase tracking-widest">
+                    To
+                  </label>
+                  <input
+                    type="date"
+                    value={filters.dateTo}
+                    onChange={(e) => set("dateTo", e.target.value)}
+                    aria-label="Filter to date"
+                    className={cn(
+                      "bg-[#0a0a0a] border border-[#333333] px-3 py-2",
+                      "text-xs text-white [color-scheme:dark]",
+                      "focus:outline-none focus:border-[#c9a962]",
+                    )}
+                  />
+                </div>
+
+                {/* Amount min */}
+                <div className="flex flex-col gap-1">
+                  <label className="text-[10px] text-[#777777] uppercase tracking-widest">
+                    Min USDC
+                  </label>
+                  <input
+                    type="number"
+                    value={filters.amountMin}
+                    onChange={(e) => set("amountMin", e.target.value)}
+                    placeholder="0"
+                    aria-label="Minimum amount"
                     className={cn(
                       "w-24 bg-[#0a0a0a] border border-[#333333] px-3 py-2",
                       "text-xs text-white placeholder-[#555555]",
-                      "focus:outline-none focus:border-[#c9a962]"
+                      "focus:outline-none focus:border-[#c9a962]",
+                    )}
+                  />
+                </div>
+
+                {/* Amount max */}
+                <div className="flex flex-col gap-1">
+                  <label className="text-[10px] text-[#777777] uppercase tracking-widest">
+                    Max USDC
+                  </label>
+                  <input
+                    type="number"
+                    value={filters.amountMax}
+                    onChange={(e) => set("amountMax", e.target.value)}
+                    placeholder="∞"
+                    aria-label="Maximum amount"
+                    className={cn(
+                      "w-24 bg-[#0a0a0a] border border-[#333333] px-3 py-2",
+                      "text-xs text-white placeholder-[#555555]",
+                      "focus:outline-none focus:border-[#c9a962]",
                     )}
                   />
                 </div>
@@ -256,7 +415,7 @@ export default function HistoryPage() {
                     className={cn(
                       "ml-auto text-[10px] tracking-widest uppercase px-3 py-2",
                       "border border-[#555555] text-[#777777]",
-                      "hover:border-[#c9a962] hover:text-[#c9a962] transition-colors duration-150"
+                      "hover:border-[#c9a962] hover:text-[#c9a962] transition-colors duration-150",
                     )}
                   >
                     Reset filters
@@ -267,21 +426,32 @@ export default function HistoryPage() {
 
             {/* ── Table ── */}
             {filtered.length === 0 ? (
-              <div className="border border-[#333333] bg-[#111111] p-12 text-center">
+              <div className="border border-[#333333] bg-[#111111] p-12 text-center mt-4">
                 <p className="text-sm text-[#777777]">
-                  {transactions.length === 0 ? "No transactions found" : "No transactions match the current filters"}
+                  {transactions.length === 0
+                    ? "No transactions found"
+                    : "No transactions match the current filters"}
                 </p>
               </div>
             ) : (
-              <div className="border border-[#333333] bg-[#111111] overflow-x-auto">
-                <table className="w-full min-w-[800px] border-collapse" aria-label="Transaction history">
+              <div className="border border-[#333333] bg-[#111111] overflow-x-auto mt-4">
+                <table
+                  className="w-full min-w-[800px] border-collapse"
+                  aria-label="Transaction history"
+                >
                   <thead>
                     <tr className="bg-[#c9a962]">
                       {/* Sortable: DATE */}
                       <th
                         className="px-5 py-2.5 text-left text-[10px] tracking-[0.18em] font-semibold text-[#0a0a0a] uppercase whitespace-nowrap cursor-pointer select-none"
                         onClick={() => toggleSort("timestamp")}
-                        aria-sort={filters.sortField === "timestamp" ? (filters.sortDir === "asc" ? "ascending" : "descending") : "none"}
+                        aria-sort={
+                          filters.sortField === "timestamp"
+                            ? filters.sortDir === "asc"
+                              ? "ascending"
+                              : "descending"
+                            : "none"
+                        }
                       >
                         DATE <SortIcon field="timestamp" />
                       </th>
@@ -292,7 +462,13 @@ export default function HistoryPage() {
                       <th
                         className="px-5 py-2.5 text-left text-[10px] tracking-[0.18em] font-semibold text-[#0a0a0a] uppercase whitespace-nowrap cursor-pointer select-none"
                         onClick={() => toggleSort("amount")}
-                        aria-sort={filters.sortField === "amount" ? (filters.sortDir === "asc" ? "ascending" : "descending") : "none"}
+                        aria-sort={
+                          filters.sortField === "amount"
+                            ? filters.sortDir === "asc"
+                              ? "ascending"
+                              : "descending"
+                            : "none"
+                        }
                       >
                         AMOUNT <SortIcon field="amount" />
                       </th>
@@ -314,7 +490,7 @@ export default function HistoryPage() {
                         className={cn(
                           "border-b border-[#222222] transition-colors duration-100",
                           i % 2 === 0 ? "bg-[#111111]" : "bg-[#0f0f0f]",
-                          "hover:bg-[#1a1a1a]"
+                          "hover:bg-[#1a1a1a]",
                         )}
                       >
                         <td className="px-5 py-3 text-xs text-[#aaaaaa] whitespace-nowrap">
@@ -331,7 +507,11 @@ export default function HistoryPage() {
                               >
                                 {truncateTxHash(tx.stellarTxHash)}
                               </a>
-                              <CopyButton text={tx.stellarTxHash} label="" className="text-[10px]" />
+                              <CopyButton
+                                text={tx.stellarTxHash}
+                                label=""
+                                className="text-[10px]"
+                              />
                             </div>
                           ) : (
                             <span className="text-[#555555]">Pending</span>
@@ -343,7 +523,10 @@ export default function HistoryPage() {
                         <td className="px-5 py-3 text-xs text-white whitespace-nowrap">
                           <span className="flex items-center gap-1.5">
                             {getCurrencyFlag(tx.currency) && (
-                              <span aria-hidden="true" className="text-base leading-none">
+                              <span
+                                aria-hidden="true"
+                                className="text-base leading-none"
+                              >
                                 {getCurrencyFlag(tx.currency)}
                               </span>
                             )}

--- a/src/hooks/usePollBridgeStatus.ts
+++ b/src/hooks/usePollBridgeStatus.ts
@@ -3,10 +3,11 @@
 import { useCallback } from 'react';
 import type { BridgeStatus } from '@/lib/offramp/types';
 import { TransactionStorage } from '@/lib/transaction-storage';
+import { usePollingManager, DurationExceededError, ConsecutiveErrorsExceededError } from '@/lib/polling/polling-manager';
+import type { StatusResponse } from '@/lib/polling/polling-manager';
+import { BRIDGE_CONFIG } from '@/lib/polling/backoff';
 
-const POLL_INTERVAL_MS = 5_000;
-const MAX_ATTEMPTS = 60;
-const MAX_CONSECUTIVE_ERRORS = 10;
+const BRIDGE_TERMINAL_STATES: BridgeStatus[] = ['completed', 'failed', 'expired'];
 
 interface PollBridgeStatusOptions {
   transactionId: string;
@@ -14,7 +15,7 @@ interface PollBridgeStatusOptions {
 }
 
 /**
- * Polls GET /api/offramp/bridge/status/{txHash} every 5 s, up to 60 attempts (5 min).
+ * Polls GET /api/offramp/bridge/status/{txHash} using exponential backoff, up to 5 min.
  * - "completed"  → calls onBridgeComplete(), resolves
  * - "failed"     → rejects with descriptive error
  * - 10 consecutive HTTP errors → soft exit (resolves without throwing)
@@ -22,46 +23,34 @@ interface PollBridgeStatusOptions {
  * Updates TransactionStorage on every successful poll.
  */
 export function usePollBridgeStatus() {
+  const { start } = usePollingManager(BRIDGE_CONFIG);
+
   const pollBridgeStatus = useCallback(
     async (txHash: string, { transactionId, onBridgeComplete }: PollBridgeStatusOptions): Promise<void> => {
-      let attempts = 0;
-      let consecutiveErrors = 0;
+      const fetchFn = async (id: string, signal: AbortSignal): Promise<StatusResponse> => {
+        const res = await fetch(`/api/offramp/bridge/status/${id}`, {
+          cache: 'no-store',
+          signal,
+        });
 
-      while (attempts < MAX_ATTEMPTS) {
-        attempts++;
+        const data: { data?: { status?: BridgeStatus }; status?: BridgeStatus; error?: string } = await res.json();
 
-        let data: { status?: BridgeStatus; error?: string };
-
-        try {
-          const res = await fetch(`/api/offramp/bridge/status/${txHash}`, { cache: 'no-store' });
-          data = await res.json();
-
-          if (!res.ok) {
-            consecutiveErrors++;
-            if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
-              // Soft exit — don't block payout polling
-              return;
-            }
-            await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-            continue;
-          }
-        } catch {
-          consecutiveErrors++;
-          if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
-            return;
-          }
-          await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-          continue;
-        }
-
-        // Reset on successful HTTP response
-        consecutiveErrors = 0;
-
-        const status = data.status;
+        // Support both wrapped { data: { status } } and flat { status } response shapes
+        const status: BridgeStatus = (data.data?.status ?? data.status ?? 'pending') as BridgeStatus;
 
         if (status) {
           TransactionStorage.update(transactionId, { bridgeStatus: status });
         }
+
+        const isTerminal = BRIDGE_TERMINAL_STATES.includes(status);
+
+        return { status, id, isTerminal };
+      };
+
+      try {
+        const result = await start(txHash, fetchFn, () => { });
+
+        const status = result.status as BridgeStatus;
 
         if (status === 'completed') {
           onBridgeComplete?.();
@@ -75,15 +64,15 @@ export function usePollBridgeStatus() {
               : 'Bridge transfer expired. Please try again.'
           );
         }
-
-        if (attempts < MAX_ATTEMPTS) {
-          await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+      } catch (err) {
+        // Total timeout or 10 consecutive errors → resolve silently (best-effort)
+        if (err instanceof DurationExceededError || err instanceof ConsecutiveErrorsExceededError) {
+          return;
         }
+        throw err;
       }
-
-      // Timeout — best-effort, resolve silently
     },
-    []
+    [start]
   );
 
   return { pollBridgeStatus };

--- a/src/hooks/usePollPayoutStatus.ts
+++ b/src/hooks/usePollPayoutStatus.ts
@@ -4,9 +4,9 @@ import { useCallback } from 'react';
 import type { PayoutStatus } from '@/lib/offramp/types';
 import { TransactionStorage } from '@/lib/transaction-storage';
 import type { OfframpStep } from '@/types/stellaramp';
-
-const POLL_INTERVAL_MS = 10_000;
-const MAX_ATTEMPTS = 60;
+import { usePollingManager, DurationExceededError, ConsecutiveErrorsExceededError } from '@/lib/polling/polling-manager';
+import type { StatusResponse } from '@/lib/polling/polling-manager';
+import { PAYOUT_CONFIG } from '@/lib/polling/backoff';
 
 const TERMINAL_STATES: PayoutStatus[] = ['validated', 'settled', 'refunded', 'expired'];
 
@@ -17,54 +17,68 @@ interface PollPayoutStatusOptions {
 }
 
 /**
- * Polls GET /api/offramp/status/{orderId} every 10 s, up to 60 attempts (10 min).
+ * Polls GET /api/offramp/status/{orderId} using exponential backoff, up to 10 min.
  * - "validated" | "settled"  → calls onSettling(), resolves
  * - "refunded" | "expired"   → rejects with descriptive error
+ * - 5 consecutive HTTP errors → rejects with descriptive connectivity error
  * - Timeout                  → rejects with "Payout polling timeout"
  * Updates TransactionStorage on every poll.
  */
 export function usePollPayoutStatus() {
+  const { start } = usePollingManager(PAYOUT_CONFIG);
+
   const pollPayoutStatus = useCallback(
     async (orderId: string, { transactionId, onSettling }: PollPayoutStatusOptions): Promise<void> => {
-      let attempts = 0;
+      const fetchFn = async (id: string, signal: AbortSignal): Promise<StatusResponse> => {
+        const res = await fetch(`/api/offramp/status/${id}`, {
+          cache: 'no-store',
+          signal,
+        });
 
-      while (attempts < MAX_ATTEMPTS) {
-        attempts++;
-
-        const res = await fetch(`/api/offramp/status/${orderId}`, { cache: 'no-store' });
         const data: { status?: PayoutStatus; error?: string } = await res.json();
 
         if (!res.ok) {
           throw new Error(data.error ?? 'Failed to fetch payout status');
         }
 
-        const status = data.status;
+        const status: PayoutStatus = (data.status ?? 'pending') as PayoutStatus;
 
         // Persist each poll result
         TransactionStorage.update(transactionId, { payoutStatus: status });
 
-        if (status && TERMINAL_STATES.includes(status)) {
-          if (status === 'validated' || status === 'settled') {
-            onSettling?.();
-            return;
-          }
-          // refunded or expired
+        const isTerminal = TERMINAL_STATES.includes(status);
+
+        return { status, id, isTerminal };
+      };
+
+      try {
+        const result = await start(orderId, fetchFn, () => { });
+
+        const status = result.status as PayoutStatus;
+
+        if (status === 'validated' || status === 'settled') {
+          onSettling?.();
+          return;
+        }
+
+        if (status === 'refunded' || status === 'expired') {
           throw new Error(
             status === 'refunded'
               ? 'Payout was refunded. Please contact support.'
               : 'Payout order expired. Please try again.'
           );
         }
-
-        // Not terminal — wait before next attempt
-        if (attempts < MAX_ATTEMPTS) {
-          await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+      } catch (err) {
+        if (err instanceof DurationExceededError) {
+          throw new Error('Payout polling timeout');
         }
+        if (err instanceof ConsecutiveErrorsExceededError) {
+          throw new Error('Payout polling failed: too many consecutive network errors. Please check your connection.');
+        }
+        throw err;
       }
-
-      throw new Error('Payout polling timeout');
     },
-    []
+    [start]
   );
 
   return { pollPayoutStatus };

--- a/src/lib/api-versioning/headers.ts
+++ b/src/lib/api-versioning/headers.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import type { VersionEntry } from "./registry";
+
+export interface VersionHeaderInjector {
+    addVersionHeader(response: NextResponse, version: string): NextResponse;
+    addDeprecationHeaders(
+        response: NextResponse,
+        entry: VersionEntry
+    ): NextResponse;
+    addSuccessorLink(response: NextResponse, legacyPath: string): NextResponse;
+}
+
+export const headerInjector: VersionHeaderInjector = {
+    addVersionHeader(response: NextResponse, version: string): NextResponse {
+        // Strip the leading 'v' to get the numeric value, e.g. 'v1' → '1'
+        const numericVersion = version.replace(/^v/, "");
+        response.headers.set("X-API-Version", numericVersion);
+        return response;
+    },
+
+    addDeprecationHeaders(
+        response: NextResponse,
+        entry: VersionEntry
+    ): NextResponse {
+        if (entry.deprecatedAt) {
+            response.headers.set("Deprecation", entry.deprecatedAt);
+        }
+        if (entry.sunsetAt) {
+            response.headers.set("Sunset", entry.sunsetAt);
+        }
+        if (entry.migrationGuideUrl) {
+            response.headers.set(
+                "Link",
+                `<${entry.migrationGuideUrl}>; rel="deprecation"`
+            );
+        }
+        return response;
+    },
+
+    addSuccessorLink(response: NextResponse, legacyPath: string): NextResponse {
+        // Normalise: strip leading slash if present, then build the v1 path
+        const cleanPath = legacyPath.replace(/^\//, "");
+        const successorUrl = `/api/v1/${cleanPath}`;
+        response.headers.set("Link", `<${successorUrl}>; rel="successor-version"`);
+        return response;
+    },
+};

--- a/src/lib/api-versioning/index.ts
+++ b/src/lib/api-versioning/index.ts
@@ -1,0 +1,11 @@
+// Registry
+export type { VersionStatus, VersionEntry, VersionRegistry } from "./registry";
+export { registry, validateRegistry } from "./registry";
+
+// Negotiator
+export type { NegotiationResult, VersionNegotiator } from "./negotiator";
+export { negotiator } from "./negotiator";
+
+// Headers
+export type { VersionHeaderInjector } from "./headers";
+export { headerInjector } from "./headers";

--- a/src/lib/api-versioning/negotiator.ts
+++ b/src/lib/api-versioning/negotiator.ts
@@ -1,0 +1,87 @@
+import { registry } from "./registry";
+
+export interface NegotiationResult {
+    version: string | null;
+    source: "url" | "x-api-version-header" | "accept-header" | "legacy-default";
+    error?: "unsupported" | "unrecognised-prefix";
+}
+
+export interface VersionNegotiator {
+    resolve(request: Request): NegotiationResult;
+}
+
+// Matches /api/v{n}/... and captures the version segment
+const VERSION_PATH_RE = /^\/api\/(v\d+)(\/|$)/;
+
+// Matches application/vnd.stellarspend.v{n}+json
+const ACCEPT_HEADER_RE = /application\/vnd\.stellarspend\.(v\d+)\+json/;
+
+function resolveFromUrl(pathname: string): NegotiationResult | null {
+    const match = VERSION_PATH_RE.exec(pathname);
+    if (!match) return null;
+
+    const version = match[1];
+    if (!registry.isKnown(version)) {
+        return { version: null, source: "url", error: "unrecognised-prefix" };
+    }
+    return { version, source: "url" };
+}
+
+function resolveFromXApiVersionHeader(
+    headerValue: string | null
+): NegotiationResult | null {
+    if (!headerValue || headerValue.trim() === "") return null;
+
+    // Normalise: accept bare numbers like "1" as well as "v1"
+    const normalised = /^\d+$/.test(headerValue.trim())
+        ? `v${headerValue.trim()}`
+        : headerValue.trim();
+
+    if (!registry.isKnown(normalised)) {
+        return {
+            version: null,
+            source: "x-api-version-header",
+            error: "unsupported",
+        };
+    }
+    return { version: normalised, source: "x-api-version-header" };
+}
+
+function resolveFromAcceptHeader(
+    headerValue: string | null
+): NegotiationResult | null {
+    if (!headerValue) return null;
+
+    const match = ACCEPT_HEADER_RE.exec(headerValue);
+    if (!match) return null;
+
+    const version = match[1];
+    if (!registry.isKnown(version)) {
+        return { version: null, source: "accept-header", error: "unsupported" };
+    }
+    return { version, source: "accept-header" };
+}
+
+export const negotiator: VersionNegotiator = {
+    resolve(request: Request): NegotiationResult {
+        const url = new URL(request.url);
+        const pathname = url.pathname;
+
+        // 1. URL path takes highest precedence
+        const fromUrl = resolveFromUrl(pathname);
+        if (fromUrl !== null) return fromUrl;
+
+        // 2. X-API-Version header
+        const xApiVersion = request.headers.get("x-api-version");
+        const fromHeader = resolveFromXApiVersionHeader(xApiVersion);
+        if (fromHeader !== null) return fromHeader;
+
+        // 3. Accept header
+        const accept = request.headers.get("accept");
+        const fromAccept = resolveFromAcceptHeader(accept);
+        if (fromAccept !== null) return fromAccept;
+
+        // 4. Legacy default — fall back to v1
+        return { version: "v1", source: "legacy-default" };
+    },
+};

--- a/src/lib/api-versioning/registry.ts
+++ b/src/lib/api-versioning/registry.ts
@@ -1,0 +1,99 @@
+export type VersionStatus = "supported" | "deprecated";
+
+export interface VersionEntry {
+    version: string; // e.g. 'v1'
+    status: VersionStatus;
+    prefix: string; // e.g. '/api/v1'
+    deprecatedAt?: string; // ISO 8601 date string, present when status === 'deprecated'
+    sunsetAt?: string; // ISO 8601 date string, present when status === 'deprecated'
+    migrationGuideUrl?: string;
+}
+
+export interface VersionRegistry {
+    getAll(): VersionEntry[];
+    get(version: string): VersionEntry | undefined;
+    isKnown(version: string): boolean;
+    isSupported(version: string): boolean;
+    isDeprecated(version: string): boolean;
+    isSunset(version: string): boolean;
+}
+
+const VERSION_REGISTRY_DATA: VersionEntry[] = [
+    {
+        version: "v1",
+        status: "supported",
+        prefix: "/api/v1",
+    },
+];
+
+export function validateRegistry(entries: VersionEntry[]): void {
+    for (const entry of entries) {
+        if (!entry.version || typeof entry.version !== "string") {
+            throw new Error(
+                `VersionRegistry misconfiguration: entry missing 'version' field`
+            );
+        }
+        if (!entry.status || !["supported", "deprecated"].includes(entry.status)) {
+            throw new Error(
+                `VersionRegistry misconfiguration: entry '${entry.version}' has invalid status '${entry.status}'`
+            );
+        }
+        if (!entry.prefix || typeof entry.prefix !== "string") {
+            throw new Error(
+                `VersionRegistry misconfiguration: entry '${entry.version}' missing 'prefix' field`
+            );
+        }
+        if (entry.status === "deprecated") {
+            if (!entry.deprecatedAt) {
+                throw new Error(
+                    `VersionRegistry misconfiguration: deprecated entry '${entry.version}' missing 'deprecatedAt'`
+                );
+            }
+            if (!entry.sunsetAt) {
+                throw new Error(
+                    `VersionRegistry misconfiguration: deprecated entry '${entry.version}' missing 'sunsetAt'`
+                );
+            }
+        }
+    }
+}
+
+// Validate at module load time
+validateRegistry(VERSION_REGISTRY_DATA);
+
+function createRegistry(entries: VersionEntry[]): VersionRegistry {
+    return {
+        getAll(): VersionEntry[] {
+            return [...entries];
+        },
+
+        get(version: string): VersionEntry | undefined {
+            return entries.find((e) => e.version === version);
+        },
+
+        isKnown(version: string): boolean {
+            return entries.some((e) => e.version === version);
+        },
+
+        isSupported(version: string): boolean {
+            const entry = entries.find((e) => e.version === version);
+            return entry?.status === "supported";
+        },
+
+        isDeprecated(version: string): boolean {
+            const entry = entries.find((e) => e.version === version);
+            if (!entry || entry.status !== "deprecated") return false;
+            if (!entry.sunsetAt) return true;
+            return new Date(entry.sunsetAt) > new Date();
+        },
+
+        isSunset(version: string): boolean {
+            const entry = entries.find((e) => e.version === version);
+            if (!entry || entry.status !== "deprecated") return false;
+            if (!entry.sunsetAt) return false;
+            return new Date(entry.sunsetAt) <= new Date();
+        },
+    };
+}
+
+export const registry: VersionRegistry = createRegistry(VERSION_REGISTRY_DATA);

--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -1,0 +1,7 @@
+import { Pool } from "pg";
+
+if (!process.env.DATABASE_URL) {
+    throw new Error("DATABASE_URL environment variable is required");
+}
+
+export const pool = new Pool({ connectionString: process.env.DATABASE_URL });

--- a/src/lib/db/dal.ts
+++ b/src/lib/db/dal.ts
@@ -1,0 +1,191 @@
+import { pool } from "./client";
+import type { Transaction } from "../transaction-storage";
+
+export class DatabaseError extends Error {
+    constructor(
+        message: string,
+        public readonly cause: unknown,
+    ) {
+        super(message);
+        this.name = "DatabaseError";
+    }
+}
+
+export interface DAL {
+    save(transaction: Transaction): Promise<void>;
+    update(id: string, updates: Partial<Transaction>): Promise<void>;
+    getByUser(userAddress: string): Promise<Transaction[]>;
+    getById(id: string): Promise<Transaction | null>;
+    getByPayoutOrderId(orderId: string): Promise<Transaction | null>;
+}
+
+// Maps a flat DB row to the nested Transaction object
+function rowToTransaction(row: Record<string, unknown>): Transaction {
+    return {
+        id: row.id as string,
+        timestamp: Number(row.timestamp),
+        userAddress: row.user_address as string,
+        amount: row.amount as string,
+        currency: row.currency as string,
+        stellarTxHash: (row.stellar_tx_hash as string | null) ?? undefined,
+        bridgeStatus: (row.bridge_status as string | null) ?? undefined,
+        payoutOrderId: (row.payout_order_id as string | null) ?? undefined,
+        payoutStatus: (row.payout_status as string | null) ?? undefined,
+        beneficiary: {
+            institution: row.beneficiary_institution as string,
+            accountIdentifier: row.beneficiary_account_identifier as string,
+            accountName: row.beneficiary_account_name as string,
+            currency: row.beneficiary_currency as string,
+        },
+        status: row.status as Transaction["status"],
+        error: (row.error as string | null) ?? undefined,
+    };
+}
+
+export const dal: DAL = {
+    async save(transaction: Transaction): Promise<void> {
+        const sql = `
+      INSERT INTO transactions (
+        id, timestamp, user_address, amount, currency,
+        stellar_tx_hash, bridge_status, payout_order_id, payout_status,
+        beneficiary_institution, beneficiary_account_identifier,
+        beneficiary_account_name, beneficiary_currency,
+        status, error
+      ) VALUES (
+        $1, $2, $3, $4, $5,
+        $6, $7, $8, $9,
+        $10, $11, $12, $13,
+        $14, $15
+      )
+    `;
+        const values = [
+            transaction.id,
+            transaction.timestamp,
+            transaction.userAddress,
+            transaction.amount,
+            transaction.currency,
+            transaction.stellarTxHash ?? null,
+            transaction.bridgeStatus ?? null,
+            transaction.payoutOrderId ?? null,
+            transaction.payoutStatus ?? null,
+            transaction.beneficiary.institution,
+            transaction.beneficiary.accountIdentifier,
+            transaction.beneficiary.accountName,
+            transaction.beneficiary.currency,
+            transaction.status,
+            transaction.error ?? null,
+        ];
+        try {
+            await pool.query(sql, values);
+        } catch (err) {
+            throw new DatabaseError(
+                `Failed to save transaction: ${(err as Error).message}`,
+                err,
+            );
+        }
+    },
+
+    async update(id: string, updates: Partial<Transaction>): Promise<void> {
+        // Build a dynamic SET clause from the updates, mapping camelCase to snake_case
+        const columnMap: Record<string, string> = {
+            timestamp: "timestamp",
+            userAddress: "user_address",
+            amount: "amount",
+            currency: "currency",
+            stellarTxHash: "stellar_tx_hash",
+            bridgeStatus: "bridge_status",
+            payoutOrderId: "payout_order_id",
+            payoutStatus: "payout_status",
+            status: "status",
+            error: "error",
+        };
+
+        const setClauses: string[] = [];
+        const values: unknown[] = [];
+        let paramIndex = 1;
+
+        for (const [key, value] of Object.entries(updates)) {
+            if (key === "beneficiary" && value && typeof value === "object") {
+                const b = value as Transaction["beneficiary"];
+                if (b.institution !== undefined) {
+                    setClauses.push(`beneficiary_institution = $${paramIndex++}`);
+                    values.push(b.institution);
+                }
+                if (b.accountIdentifier !== undefined) {
+                    setClauses.push(`beneficiary_account_identifier = $${paramIndex++}`);
+                    values.push(b.accountIdentifier);
+                }
+                if (b.accountName !== undefined) {
+                    setClauses.push(`beneficiary_account_name = $${paramIndex++}`);
+                    values.push(b.accountName);
+                }
+                if (b.currency !== undefined) {
+                    setClauses.push(`beneficiary_currency = $${paramIndex++}`);
+                    values.push(b.currency);
+                }
+            } else if (key in columnMap) {
+                setClauses.push(`${columnMap[key]} = $${paramIndex++}`);
+                values.push(value ?? null);
+            }
+        }
+
+        if (setClauses.length === 0) return;
+
+        values.push(id);
+        const sql = `UPDATE transactions SET ${setClauses.join(", ")} WHERE id = $${paramIndex}`;
+
+        try {
+            await pool.query(sql, values);
+        } catch (err) {
+            throw new DatabaseError(
+                `Failed to update transaction ${id}: ${(err as Error).message}`,
+                err,
+            );
+        }
+    },
+
+    async getByUser(userAddress: string): Promise<Transaction[]> {
+        const sql = `
+      SELECT * FROM transactions
+      WHERE LOWER(user_address) = LOWER($1)
+      ORDER BY timestamp DESC
+    `;
+        try {
+            const result = await pool.query(sql, [userAddress]);
+            return result.rows.map(rowToTransaction);
+        } catch (err) {
+            throw new DatabaseError(
+                `Failed to get transactions for user ${userAddress}: ${(err as Error).message}`,
+                err,
+            );
+        }
+    },
+
+    async getById(id: string): Promise<Transaction | null> {
+        const sql = `SELECT * FROM transactions WHERE id = $1`;
+        try {
+            const result = await pool.query(sql, [id]);
+            if (result.rows.length === 0) return null;
+            return rowToTransaction(result.rows[0]);
+        } catch (err) {
+            throw new DatabaseError(
+                `Failed to get transaction ${id}: ${(err as Error).message}`,
+                err,
+            );
+        }
+    },
+
+    async getByPayoutOrderId(orderId: string): Promise<Transaction | null> {
+        const sql = `SELECT * FROM transactions WHERE payout_order_id = $1`;
+        try {
+            const result = await pool.query(sql, [orderId]);
+            if (result.rows.length === 0) return null;
+            return rowToTransaction(result.rows[0]);
+        } catch (err) {
+            throw new DatabaseError(
+                `Failed to get transaction by payout order id ${orderId}: ${(err as Error).message}`,
+                err,
+            );
+        }
+    },
+};

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -6,6 +6,7 @@ const requiredServerEnvKeys = [
   "BASE_RPC_URL",
   "STELLAR_SOROBAN_RPC_URL",
   "STELLAR_HORIZON_URL",
+  "DATABASE_URL",
 ] as const;
 
 const requiredPublicEnvKeys = [

--- a/src/lib/polling/backoff.ts
+++ b/src/lib/polling/backoff.ts
@@ -1,0 +1,48 @@
+export interface PollingConfig {
+    baseDelay: number; // ms, default 2000
+    maxDelay: number; // ms, default 30000
+    jitterFactor: number; // 0–1, default 0.2 (20%)
+    requestTimeoutMs: number; // default 8000
+    maxTotalDurationMs: number; // bridge: 300000, payout: 600000
+    maxConsecutiveErrors: number; // bridge: 10, payout: 5
+}
+
+export interface BackoffCalculator {
+    calculate(attempt: number, config: Pick<PollingConfig, "baseDelay" | "maxDelay" | "jitterFactor">): number;
+}
+
+/**
+ * Calculates the backoff interval in milliseconds.
+ * Formula: min(base * 2^(attempt-1), max) + random jitter up to jitterFactor * base_interval
+ */
+export function calculateBackoff(
+    attempt: number,
+    config: Pick<PollingConfig, "baseDelay" | "maxDelay" | "jitterFactor">,
+): number {
+    const { baseDelay, maxDelay, jitterFactor } = config;
+    const baseInterval = Math.min(baseDelay * Math.pow(2, attempt - 1), maxDelay);
+    const jitter = Math.random() * jitterFactor * baseInterval;
+    return baseInterval + jitter;
+}
+
+export const backoffCalculator: BackoffCalculator = {
+    calculate: calculateBackoff,
+};
+
+export const BRIDGE_CONFIG: PollingConfig = {
+    baseDelay: 2000,
+    maxDelay: 30000,
+    jitterFactor: 0.2,
+    requestTimeoutMs: 8000,
+    maxTotalDurationMs: 300_000, // 5 min
+    maxConsecutiveErrors: 10,
+};
+
+export const PAYOUT_CONFIG: PollingConfig = {
+    baseDelay: 2000,
+    maxDelay: 30000,
+    jitterFactor: 0.2,
+    requestTimeoutMs: 8000,
+    maxTotalDurationMs: 600_000, // 10 min
+    maxConsecutiveErrors: 5,
+};

--- a/src/lib/polling/polling-manager.ts
+++ b/src/lib/polling/polling-manager.ts
@@ -1,0 +1,298 @@
+'use client';
+
+import { useCallback, useRef } from 'react';
+import { calculateBackoff, type PollingConfig } from './backoff';
+import { connectWebSocket } from './websocket-client';
+import type { StatusPush } from './ws-server';
+
+export interface PollingState {
+    elapsedMs: number;
+    remainingMs: number;
+    attemptNumber: number;
+}
+
+export interface StatusResponse {
+    status: string;
+    id: string;
+    isTerminal: boolean;
+    cachedAt?: number;
+    upstreamError?: string;
+}
+
+// Module-level deduplication map: id → AbortController of the in-flight request
+// Requirement 4.1, 4.3, 4.4
+const inFlight = new Map<string, AbortController>();
+
+export function usePollingManager(config: PollingConfig): {
+    start(
+        id: string,
+        fetchFn: (id: string, signal: AbortSignal) => Promise<StatusResponse>,
+        onUpdate: (state: PollingState) => void,
+    ): Promise<StatusResponse>;
+    stop(): void;
+} {
+    // Ref to signal the polling loop to stop (e.g. on component unmount)
+    const stoppedRef = useRef(false);
+    // Ref to the current request's AbortController so stop() can abort it
+    const currentControllerRef = useRef<AbortController | null>(null);
+    // Ref to the visibility-change handler so we can remove it on stop
+    const visibilityHandlerRef = useRef<(() => void) | null>(null);
+    // Ref to the sleep-resolve function so visibility resume can wake the loop
+    const sleepResolveRef = useRef<(() => void) | null>(null);
+    // Ref to the WebSocket cleanup function
+    const wsCleanupRef = useRef<(() => void) | null>(null);
+
+    const stop = useCallback(() => {
+        stoppedRef.current = true;
+        currentControllerRef.current?.abort();
+        // Close any active WebSocket connection
+        wsCleanupRef.current?.();
+        wsCleanupRef.current = null;
+        if (visibilityHandlerRef.current) {
+            document.removeEventListener('visibilitychange', visibilityHandlerRef.current);
+            visibilityHandlerRef.current = null;
+        }
+        // Wake any sleeping interval so the loop can exit promptly
+        sleepResolveRef.current?.();
+    }, []);
+
+    const start = useCallback(
+        async (
+            id: string,
+            fetchFn: (id: string, signal: AbortSignal) => Promise<StatusResponse>,
+            onUpdate: (state: PollingState) => void,
+        ): Promise<StatusResponse> => {
+            stoppedRef.current = false;
+
+            const startTime = Date.now();
+            let attemptNumber = 0;
+            let consecutiveErrors = 0;
+            let paused = false;
+
+            // Page Visibility API — pause when hidden, resume when visible (Req 4.5, 4.6)
+            const visibilityHandler = () => {
+                if (document.visibilityState === 'hidden') {
+                    paused = true;
+                } else {
+                    paused = false;
+                    // Wake the sleep so we poll immediately on resume (Req 4.6)
+                    sleepResolveRef.current?.();
+                }
+            };
+            visibilityHandlerRef.current = visibilityHandler;
+            document.addEventListener('visibilitychange', visibilityHandler);
+
+            // ----------------------------------------------------------------
+            // WebSocket-first: attempt WS connection before starting HTTP polling
+            // Property 6: while WS is active, HTTP polling is suspended
+            // Property 7: when WS closes/errors, fall back to HTTP polling
+            // Requirements: 2.3, 2.4, 4.2
+            // ----------------------------------------------------------------
+            let wsActive = false;
+            // Resolve function to wake the HTTP polling loop when WS closes
+            let wsClosedResolve: (() => void) | null = null;
+            // Promise that resolves when the WS connection closes
+            let wsClosedPromise: Promise<void> | null = null;
+
+            // Promise that resolves with a terminal StatusResponse if WS delivers one
+            let wsTerminalResolve: ((r: StatusResponse) => void) | null = null;
+            const wsTerminalPromise = new Promise<StatusResponse | null>((resolve) => {
+                wsTerminalResolve = (r) => resolve(r);
+            });
+
+            // Attempt WebSocket connection
+            try {
+                wsClosedPromise = new Promise<void>((resolve) => {
+                    wsClosedResolve = resolve;
+                });
+
+                const wsCleanup = connectWebSocket(
+                    id,
+                    (push: StatusPush) => {
+                        if (stoppedRef.current) return;
+
+                        // Convert StatusPush to StatusResponse shape
+                        const response: StatusResponse = {
+                            id: push.id,
+                            status: push.status,
+                            isTerminal: push.isTerminal,
+                        };
+
+                        const nowElapsed = Date.now() - startTime;
+                        const nowRemaining = config.maxTotalDurationMs - nowElapsed;
+                        attemptNumber++;
+                        onUpdate({ elapsedMs: nowElapsed, remainingMs: nowRemaining, attemptNumber });
+
+                        if (push.isTerminal) {
+                            // Terminal state via WS — resolve the whole start() promise
+                            wsTerminalResolve?.(response);
+                        }
+                    },
+                    () => {
+                        // WS closed or errored — wake HTTP polling fallback
+                        wsActive = false;
+                        wsCleanupRef.current = null;
+                        wsClosedResolve?.();
+                    },
+                );
+
+                wsActive = true;
+                wsCleanupRef.current = wsCleanup;
+            } catch {
+                // WebSocket constructor threw (e.g. in SSR/test env) — fall through to HTTP
+                wsActive = false;
+                wsClosedPromise = Promise.resolve();
+            }
+
+            try {
+                // If WS connected, wait for either a terminal push or the WS to close
+                if (wsActive && wsClosedPromise) {
+                    const result = await Promise.race([
+                        wsTerminalPromise,
+                        wsClosedPromise.then(() => null as StatusResponse | null),
+                    ]);
+
+                    if (stoppedRef.current) {
+                        throw new AbortError('polling stopped');
+                    }
+
+                    if (result !== null) {
+                        // Terminal state delivered via WebSocket
+                        return result;
+                    }
+                    // WS closed without terminal state — fall through to HTTP polling
+                }
+
+                // Resolve the wsTerminalPromise so it doesn't linger
+                wsTerminalResolve?.(null as unknown as StatusResponse);
+
+                // ----------------------------------------------------------------
+                // HTTP polling loop (fallback or primary when WS unavailable)
+                // ----------------------------------------------------------------
+                while (!stoppedRef.current) {
+                    const elapsedMs = Date.now() - startTime;
+                    const remainingMs = config.maxTotalDurationMs - elapsedMs;
+
+                    // Total duration exceeded — caller decides resolve vs reject
+                    if (remainingMs <= 0) {
+                        throw new DurationExceededError('max total duration exceeded');
+                    }
+
+                    // Wait while paused (tab hidden)
+                    while (paused && !stoppedRef.current) {
+                        await new Promise<void>((resolve) => {
+                            sleepResolveRef.current = resolve;
+                        });
+                        sleepResolveRef.current = null;
+                    }
+
+                    if (stoppedRef.current) break;
+
+                    attemptNumber++;
+
+                    // Deduplication: abort any existing in-flight request for this id (Req 4.1)
+                    if (inFlight.has(id)) {
+                        inFlight.get(id)!.abort();
+                    }
+
+                    // Per-request AbortController with 8s timeout (Req 5.1, 5.2)
+                    const controller = new AbortController();
+                    currentControllerRef.current = controller;
+                    inFlight.set(id, controller);
+
+                    const timeoutId = setTimeout(
+                        () => controller.abort(),
+                        config.requestTimeoutMs,
+                    );
+
+                    let response: StatusResponse | null = null;
+                    let requestFailed = false;
+
+                    try {
+                        response = await fetchFn(id, controller.signal);
+                        consecutiveErrors = 0;
+                    } catch {
+                        requestFailed = true;
+                        consecutiveErrors++;
+                    } finally {
+                        clearTimeout(timeoutId);
+                        // Only remove from inFlight if this controller is still the current one
+                        if (inFlight.get(id) === controller) {
+                            inFlight.delete(id);
+                        }
+                    }
+
+                    if (stoppedRef.current) break;
+
+                    const nowElapsed = Date.now() - startTime;
+                    const nowRemaining = config.maxTotalDurationMs - nowElapsed;
+
+                    // Notify caller of current state (Req 5.7)
+                    onUpdate({ elapsedMs: nowElapsed, remainingMs: nowRemaining, attemptNumber });
+
+                    // Check consecutive error threshold
+                    if (requestFailed) {
+                        if (consecutiveErrors >= config.maxConsecutiveErrors) {
+                            throw new ConsecutiveErrorsExceededError(
+                                `${consecutiveErrors} consecutive poll failures`,
+                            );
+                        }
+                    } else if (response) {
+                        // Terminal state — stop immediately (Req 1.4)
+                        if (response.isTerminal) {
+                            return response;
+                        }
+                    }
+
+                    // Check total duration again before sleeping
+                    const elapsedBeforeSleep = Date.now() - startTime;
+                    if (elapsedBeforeSleep >= config.maxTotalDurationMs) {
+                        throw new DurationExceededError('max total duration exceeded');
+                    }
+
+                    // Backoff sleep (Req 1.1, 1.2, 1.3)
+                    const delay = calculateBackoff(attemptNumber, config);
+                    await new Promise<void>((resolve) => {
+                        sleepResolveRef.current = resolve;
+                        setTimeout(resolve, delay);
+                    });
+                    sleepResolveRef.current = null;
+                }
+
+                // Loop exited because stop() was called
+                throw new AbortError('polling stopped');
+            } finally {
+                document.removeEventListener('visibilitychange', visibilityHandler);
+                visibilityHandlerRef.current = null;
+                // Clean up WebSocket if still open
+                wsCleanupRef.current?.();
+                wsCleanupRef.current = null;
+            }
+        },
+        [config],
+    );
+
+    return { start, stop };
+}
+
+// Typed error classes so callers can distinguish stop reasons
+export class DurationExceededError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'DurationExceededError';
+    }
+}
+
+export class ConsecutiveErrorsExceededError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ConsecutiveErrorsExceededError';
+    }
+}
+
+export class AbortError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'AbortError';
+    }
+}

--- a/src/lib/polling/status-cache.ts
+++ b/src/lib/polling/status-cache.ts
@@ -1,0 +1,41 @@
+export interface CacheEntry {
+    status: string;
+    raw: unknown;
+    cachedAt: number; // Date.now()
+    isTerminal: boolean;
+}
+
+const TTL_MS = 3000; // 3 seconds for non-terminal entries
+const TERMINAL_RETENTION_MS = 60_000; // 60 seconds minimum for terminal entries
+
+// Module-level singleton cache — keyed by `${NODE_ENV}:${id}`
+const cache = new Map<string, CacheEntry>();
+
+function buildKey(id: string): string {
+    return `${process.env.NODE_ENV ?? "development"}:${id}`;
+}
+
+export function get(id: string): CacheEntry | undefined {
+    return cache.get(buildKey(id));
+}
+
+export function set(id: string, entry: CacheEntry): void {
+    cache.set(buildKey(id), entry);
+}
+
+/**
+ * Returns true if the entry is still fresh and should be served from cache.
+ * - Non-terminal: fresh if age < TTL_MS (3s)
+ * - Terminal: retained for at least TERMINAL_RETENTION_MS (60s)
+ */
+export function isFresh(entry: CacheEntry): boolean {
+    const age = Date.now() - entry.cachedAt;
+    if (entry.isTerminal) {
+        return age < TERMINAL_RETENTION_MS;
+    }
+    return age < TTL_MS;
+}
+
+export function clear(): void {
+    cache.clear();
+}

--- a/src/lib/polling/websocket-client.ts
+++ b/src/lib/polling/websocket-client.ts
@@ -1,0 +1,75 @@
+'use client';
+
+import type { StatusPush } from './ws-server';
+
+export type { StatusPush };
+
+export interface WebSocketClient {
+    connect(
+        id: string,
+        onMessage: (push: StatusPush) => void,
+        onClose: () => void,
+    ): () => void;
+}
+
+/**
+ * Connect to the WebSocket server at /api/offramp/ws/{id}.
+ *
+ * - Automatically selects ws:// or wss:// based on the current page protocol.
+ * - Parses incoming messages as StatusPush objects and forwards them to onMessage.
+ * - Responds to server heartbeat pings ({ type: 'ping' }) with { type: 'pong' }.
+ * - Calls onClose when the connection closes or errors.
+ * - Returns a cleanup function that closes the socket.
+ *
+ * Requirements: 2.3, 2.4, 2.7
+ */
+export function connectWebSocket(
+    id: string,
+    onMessage: (push: StatusPush) => void,
+    onClose: () => void,
+): () => void {
+    const protocol = typeof window !== 'undefined' && window.location.protocol === 'https:'
+        ? 'wss:'
+        : 'ws:';
+    const host = typeof window !== 'undefined' ? window.location.host : 'localhost';
+    const url = `${protocol}//${host}/api/offramp/ws/${id}`;
+
+    const socket = new WebSocket(url);
+
+    socket.addEventListener('message', (event: MessageEvent) => {
+        try {
+            const data = JSON.parse(event.data as string);
+
+            // Respond to server heartbeat pings (Requirement 2.7)
+            if (data?.type === 'ping') {
+                if (socket.readyState === WebSocket.OPEN) {
+                    socket.send(JSON.stringify({ type: 'pong' }));
+                }
+                return;
+            }
+
+            // Forward status push messages to the caller
+            if (data && typeof data.id === 'string' && typeof data.status === 'string') {
+                onMessage(data as StatusPush);
+            }
+        } catch {
+            // Non-JSON or malformed message — ignore
+        }
+    });
+
+    socket.addEventListener('close', () => {
+        onClose();
+    });
+
+    socket.addEventListener('error', () => {
+        // The 'close' event fires after 'error', so onClose will be called there.
+        // No additional action needed here.
+    });
+
+    // Return cleanup function that closes the socket (Requirement 2.3)
+    return () => {
+        if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+            socket.close(1000, 'client cleanup');
+        }
+    };
+}

--- a/src/lib/polling/ws-server.ts
+++ b/src/lib/polling/ws-server.ts
@@ -1,0 +1,156 @@
+/**
+ * WebSocket server utilities for transaction status push delivery.
+ *
+ * NOTE: Next.js App Router does not natively support WebSocket upgrades in
+ * route handlers. These utilities are designed to be used with a custom
+ * Node.js server (e.g. via `scripts/run-next.cjs`) that can intercept the
+ * HTTP upgrade event and call `onConnect` directly.
+ *
+ * The route at /api/offramp/ws/[id] returns 501 when hit via a normal HTTP
+ * request, but exports these utilities so the custom server can import and
+ * use them.
+ */
+
+export interface StatusPush {
+    id: string;
+    status: string;
+    isTerminal: boolean;
+    timestamp: number;
+}
+
+// Module-level subscriber map: transactionId → Set of connected WebSocket clients
+// Property 5: broadcast reaches all subscribers for a given id
+const subscribers = new Map<string, Set<WebSocket>>();
+
+// Heartbeat tracking: socket → { pingTimer, pongTimer }
+const heartbeats = new Map<
+    WebSocket,
+    { pingTimer: ReturnType<typeof setTimeout>; pongTimer: ReturnType<typeof setTimeout> | null }
+>();
+
+const HEARTBEAT_INTERVAL_MS = 60_000; // 60s of inactivity before ping
+const PONG_TIMEOUT_MS = 10_000; // close if pong not received within 10s
+
+function scheduleHeartbeat(socket: WebSocket): void {
+    const existing = heartbeats.get(socket);
+    if (existing) {
+        clearTimeout(existing.pingTimer);
+        if (existing.pongTimer) clearTimeout(existing.pongTimer);
+    }
+
+    const pingTimer = setTimeout(() => {
+        if (socket.readyState !== socket.OPEN) {
+            heartbeats.delete(socket);
+            return;
+        }
+
+        // Send ping
+        try {
+            // Native WebSocket API uses send; ws library exposes ping()
+            // We use a JSON ping message for compatibility with browser WebSocket
+            socket.send(JSON.stringify({ type: 'ping' }));
+        } catch {
+            // Socket already closed
+            heartbeats.delete(socket);
+            return;
+        }
+
+        // Expect pong within 10s
+        const pongTimer = setTimeout(() => {
+            socket.close(1001, 'pong timeout');
+            heartbeats.delete(socket);
+        }, PONG_TIMEOUT_MS);
+
+        heartbeats.set(socket, { pingTimer, pongTimer });
+    }, HEARTBEAT_INTERVAL_MS);
+
+    heartbeats.set(socket, { pingTimer, pongTimer: null });
+}
+
+function cancelHeartbeat(socket: WebSocket): void {
+    const entry = heartbeats.get(socket);
+    if (entry) {
+        clearTimeout(entry.pingTimer);
+        if (entry.pongTimer) clearTimeout(entry.pongTimer);
+        heartbeats.delete(socket);
+    }
+}
+
+/**
+ * Called when a client connects; subscribes them to updates for `id`.
+ * Property 5: all subscribers for an id receive broadcasts.
+ */
+export function onConnect(id: string, socket: WebSocket): void {
+    if (!subscribers.has(id)) {
+        subscribers.set(id, new Set());
+    }
+    subscribers.get(id)!.add(socket);
+
+    // Handle pong responses (reset heartbeat timer)
+    socket.addEventListener('message', (event: MessageEvent) => {
+        try {
+            const data = JSON.parse(event.data as string);
+            if (data?.type === 'pong') {
+                const entry = heartbeats.get(socket);
+                if (entry?.pongTimer) {
+                    clearTimeout(entry.pongTimer);
+                }
+                // Reschedule next heartbeat
+                scheduleHeartbeat(socket);
+            }
+        } catch {
+            // Non-JSON message — ignore
+        }
+    });
+
+    socket.addEventListener('close', () => {
+        cancelHeartbeat(socket);
+        const set = subscribers.get(id);
+        if (set) {
+            set.delete(socket);
+            if (set.size === 0) subscribers.delete(id);
+        }
+    });
+
+    scheduleHeartbeat(socket);
+}
+
+/**
+ * Push a status update to all subscribers for `id`.
+ * Property 5: every connected client for `id` receives the payload.
+ */
+export function broadcast(id: string, payload: StatusPush): void {
+    const set = subscribers.get(id);
+    if (!set || set.size === 0) return;
+
+    const message = JSON.stringify(payload);
+    for (const socket of set) {
+        if (socket.readyState === socket.OPEN) {
+            socket.send(message);
+            // Reset heartbeat timer on activity
+            scheduleHeartbeat(socket);
+        }
+    }
+}
+
+/**
+ * Broadcast a terminal status then close all sockets for `id`.
+ * Property 8: terminal state closes the WebSocket connection after delivery.
+ */
+export function closeForId(id: string, finalPayload: StatusPush): void {
+    const set = subscribers.get(id);
+    if (!set || set.size === 0) return;
+
+    const message = JSON.stringify(finalPayload);
+    for (const socket of set) {
+        if (socket.readyState === socket.OPEN) {
+            socket.send(message);
+        }
+        cancelHeartbeat(socket);
+        socket.close(1000, 'terminal state reached');
+    }
+    subscribers.delete(id);
+}
+
+// Exported for testing
+export { subscribers };

--- a/src/lib/webhook/alert-service.ts
+++ b/src/lib/webhook/alert-service.ts
@@ -1,0 +1,83 @@
+import type { DLQEntry } from "./types";
+import { getWebhookConfig } from "./config";
+
+export interface AlertPayload {
+    deliveryId: string;
+    destinationUrl: string;
+    totalAttempts: number;
+    lastError: string;
+    finalFailureTime: string;
+}
+
+interface AggregatedWindow {
+    payload: AlertPayload;
+    windowStart: number; // ms timestamp
+}
+
+// In-memory map: destinationUrl -> aggregated window
+const alertWindows = new Map<string, AggregatedWindow>();
+
+const WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+
+function buildPayload(entry: DLQEntry): AlertPayload {
+    return {
+        deliveryId: entry.deliveryId,
+        destinationUrl: entry.destinationUrl,
+        totalAttempts: entry.attempts.length,
+        lastError: entry.finalError,
+        finalFailureTime: entry.addedAt,
+    };
+}
+
+async function sendAlert(payload: AlertPayload): Promise<void> {
+    const config = getWebhookConfig();
+    const url = config.alertChannelUrl;
+
+    try {
+        const response = await fetch(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+            throw new Error(`Alert endpoint responded with HTTP ${response.status}`);
+        }
+    } catch (err) {
+        console.error("Failed to deliver webhook alert", {
+            alert: JSON.stringify(payload),
+            error: err instanceof Error ? err.message : String(err),
+        });
+    }
+}
+
+/**
+ * Aggregate failures per destinationUrl within a 5-minute window.
+ * Only one alert is sent per URL per window.
+ */
+export async function notify(entry: DLQEntry): Promise<void> {
+    const now = Date.now();
+    const existing = alertWindows.get(entry.destinationUrl);
+
+    if (existing && now - existing.windowStart < WINDOW_MS) {
+        // Within the suppression window — update the aggregated payload but don't re-send
+        existing.payload = buildPayload(entry);
+        return;
+    }
+
+    // New window: record it and send immediately
+    const payload = buildPayload(entry);
+    alertWindows.set(entry.destinationUrl, { payload, windowStart: now });
+    await sendAlert(payload);
+}
+
+/**
+ * Flush any pending aggregated alerts immediately, regardless of window state.
+ * Clears the in-memory map after sending.
+ */
+export async function flush(): Promise<void> {
+    const entries = Array.from(alertWindows.values());
+    alertWindows.clear();
+
+    await Promise.all(entries.map((w) => sendAlert(w.payload)));
+}

--- a/src/lib/webhook/config.ts
+++ b/src/lib/webhook/config.ts
@@ -1,0 +1,55 @@
+import type { WebhookRetryConfig } from "./types";
+
+function isMissing(value: string | undefined): boolean {
+    return !value || value.trim().length === 0;
+}
+
+function parsePositiveInt(value: string | undefined, name: string, defaultValue: number): number {
+    if (isMissing(value)) return defaultValue;
+    const parsed = parseInt(value!, 10);
+    if (isNaN(parsed) || parsed <= 0) {
+        throw new Error(`Invalid environment variable ${name}: must be a positive integer, got "${value}"`);
+    }
+    return parsed;
+}
+
+export function validateWebhookEnv(): WebhookRetryConfig {
+    const alertChannelUrl = process.env.WEBHOOK_ALERT_CHANNEL_URL;
+    if (isMissing(alertChannelUrl)) {
+        throw new Error(
+            "Invalid environment configuration for webhook retry mechanism.\n" +
+            "Missing required env var: WEBHOOK_ALERT_CHANNEL_URL"
+        );
+    }
+
+    const baseDelaySeconds = parsePositiveInt(
+        process.env.WEBHOOK_RETRY_BASE_DELAY_SECONDS,
+        "WEBHOOK_RETRY_BASE_DELAY_SECONDS",
+        30
+    );
+
+    const maxAttempts = parsePositiveInt(
+        process.env.WEBHOOK_RETRY_MAX_ATTEMPTS,
+        "WEBHOOK_RETRY_MAX_ATTEMPTS",
+        5
+    );
+
+    const alertSuppressionSeconds = parsePositiveInt(
+        process.env.WEBHOOK_ALERT_SUPPRESSION_SECONDS,
+        "WEBHOOK_ALERT_SUPPRESSION_SECONDS",
+        300
+    );
+
+    return {
+        baseDelaySeconds,
+        maxAttempts,
+        jitterFactor: 0.25,
+        alertChannelUrl: alertChannelUrl!,
+        alertSuppressionSeconds,
+        dlqRetentionDays: 30,
+    };
+}
+
+export function getWebhookConfig(): WebhookRetryConfig {
+    return validateWebhookEnv();
+}

--- a/src/lib/webhook/delivery-store.ts
+++ b/src/lib/webhook/delivery-store.ts
@@ -1,0 +1,154 @@
+import { randomUUID } from "crypto";
+import { pool } from "../db/client";
+import type { DeliveryRecord, DeliveryStatus, DeliveryAttempt, WebhookPayload } from "./types";
+
+export class DeliveryStoreError extends Error {
+    constructor(
+        message: string,
+        public readonly cause: unknown,
+    ) {
+        super(message);
+        this.name = "DeliveryStoreError";
+    }
+}
+
+/** Creates the delivery_records table if it does not already exist. */
+export async function createTable(): Promise<void> {
+    const sql = `
+        CREATE TABLE IF NOT EXISTS delivery_records (
+            id TEXT PRIMARY KEY,
+            destination_url TEXT NOT NULL,
+            payload JSONB NOT NULL,
+            status TEXT NOT NULL,
+            attempt_count INTEGER NOT NULL DEFAULT 0,
+            max_attempts INTEGER NOT NULL DEFAULT 5,
+            attempts JSONB NOT NULL DEFAULT '[]',
+            next_attempt_at TIMESTAMPTZ,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+    `;
+    try {
+        await pool.query(sql);
+    } catch (err) {
+        throw new DeliveryStoreError("Failed to create delivery_records table", err);
+    }
+}
+
+function rowToRecord(row: Record<string, unknown>): DeliveryRecord {
+    return {
+        id: row.id as string,
+        destinationUrl: row.destination_url as string,
+        payload: row.payload as WebhookPayload,
+        status: row.status as DeliveryStatus,
+        attemptCount: row.attempt_count as number,
+        maxAttempts: row.max_attempts as number,
+        attempts: (row.attempts as DeliveryAttempt[]) ?? [],
+        nextAttemptAt: row.next_attempt_at
+            ? (row.next_attempt_at as Date).toISOString()
+            : null,
+        createdAt: (row.created_at as Date).toISOString(),
+        updatedAt: (row.updated_at as Date).toISOString(),
+    };
+}
+
+/** Create a new DeliveryRecord with a generated UUID id. */
+export async function createRecord(
+    destinationUrl: string,
+    payload: WebhookPayload,
+    maxAttempts = 5,
+): Promise<DeliveryRecord> {
+    const id = randomUUID();
+    const sql = `
+        INSERT INTO delivery_records
+            (id, destination_url, payload, status, attempt_count, max_attempts, attempts, next_attempt_at)
+        VALUES ($1, $2, $3, 'pending', 0, $4, '[]', NOW())
+        RETURNING *
+    `;
+    try {
+        const result = await pool.query(sql, [id, destinationUrl, JSON.stringify(payload), maxAttempts]);
+        return rowToRecord(result.rows[0]);
+    } catch (err) {
+        throw new DeliveryStoreError("Failed to create delivery record", err);
+    }
+}
+
+/** Retrieve a single DeliveryRecord by id. Returns null if not found. */
+export async function getRecord(id: string): Promise<DeliveryRecord | null> {
+    const sql = `SELECT * FROM delivery_records WHERE id = $1`;
+    try {
+        const result = await pool.query(sql, [id]);
+        if (result.rows.length === 0) return null;
+        return rowToRecord(result.rows[0]);
+    } catch (err) {
+        throw new DeliveryStoreError(`Failed to get delivery record ${id}`, err);
+    }
+}
+
+/** Update fields on an existing DeliveryRecord. updated_at is always refreshed. */
+export async function updateRecord(
+    id: string,
+    updates: Partial<Pick<DeliveryRecord, "status" | "attemptCount" | "attempts" | "nextAttemptAt">>,
+): Promise<DeliveryRecord> {
+    const columnMap: Record<string, string> = {
+        status: "status",
+        attemptCount: "attempt_count",
+        attempts: "attempts",
+        nextAttemptAt: "next_attempt_at",
+    };
+
+    const setClauses: string[] = ["updated_at = NOW()"];
+    const values: unknown[] = [];
+    let paramIndex = 1;
+
+    for (const [key, value] of Object.entries(updates)) {
+        if (key in columnMap) {
+            const dbValue = key === "attempts" ? JSON.stringify(value) : (value ?? null);
+            setClauses.push(`${columnMap[key]} = $${paramIndex++}`);
+            values.push(dbValue);
+        }
+    }
+
+    values.push(id);
+    const sql = `UPDATE delivery_records SET ${setClauses.join(", ")} WHERE id = $${paramIndex} RETURNING *`;
+
+    try {
+        const result = await pool.query(sql, values);
+        if (result.rows.length === 0) {
+            throw new DeliveryStoreError(`Delivery record ${id} not found`, null);
+        }
+        return rowToRecord(result.rows[0]);
+    } catch (err) {
+        if (err instanceof DeliveryStoreError) throw err;
+        throw new DeliveryStoreError(`Failed to update delivery record ${id}`, err);
+    }
+}
+
+/**
+ * Query records that are due for retry:
+ * status = 'pending' AND next_attempt_at <= NOW()
+ */
+export async function getDueRecords(): Promise<DeliveryRecord[]> {
+    const sql = `
+        SELECT * FROM delivery_records
+        WHERE status = 'pending' AND next_attempt_at <= NOW()
+        ORDER BY next_attempt_at ASC
+    `;
+    try {
+        const result = await pool.query(sql);
+        return result.rows.map(rowToRecord);
+    } catch (err) {
+        throw new DeliveryStoreError("Failed to query due delivery records", err);
+    }
+}
+
+/** List all records with a given status. */
+export async function getRecordsByStatus(status: DeliveryStatus): Promise<DeliveryRecord[]> {
+    const sql = `SELECT * FROM delivery_records WHERE status = $1 ORDER BY created_at DESC`;
+    try {
+        const result = await pool.query(sql, [status]);
+        return result.rows.map(rowToRecord);
+    } catch (err) {
+        throw new DeliveryStoreError(`Failed to query delivery records with status ${status}`, err);
+    }
+}

--- a/src/lib/webhook/dispatcher.ts
+++ b/src/lib/webhook/dispatcher.ts
@@ -1,0 +1,183 @@
+import { randomUUID } from "crypto";
+import type { DeliveryRecord, DeliveryAttempt, WebhookPayload } from "./types";
+import { createRecord, updateRecord } from "./delivery-store";
+import { getWebhookConfig } from "./config";
+
+export interface DeliveryAttemptResult {
+    success: boolean;
+    retryable: boolean;
+    httpStatus?: number;
+    errorType?: string;
+    durationMs: number;
+}
+
+/**
+ * Enqueue a new delivery record for the given payload and destination.
+ */
+export async function enqueue(
+    payload: WebhookPayload,
+    destination: string,
+): Promise<DeliveryRecord> {
+    const config = getWebhookConfig();
+    return createRecord(destination, payload, config.maxAttempts);
+}
+
+/**
+ * Execute a single delivery attempt for the given record.
+ * Performs an HTTP POST, records the outcome, and updates the record in the store.
+ */
+export async function attempt(record: DeliveryRecord): Promise<DeliveryAttemptResult> {
+    const attemptNumber = record.attemptCount + 1;
+    const startTime = Date.now();
+    let httpStatus: number | undefined;
+    let errorType: string | undefined;
+    let success = false;
+    let retryable = false;
+
+    try {
+        const response = await fetch(record.destinationUrl, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                ...record.payload.headers,
+            },
+            body: record.payload.body,
+        });
+
+        httpStatus = response.status;
+        const durationMs = Date.now() - startTime;
+
+        if (httpStatus >= 200 && httpStatus < 300) {
+            success = true;
+            retryable = false;
+        } else if (httpStatus === 429) {
+            success = false;
+            retryable = true;
+        } else if (httpStatus >= 400 && httpStatus < 500) {
+            // 4xx (except 429) — non-retryable
+            success = false;
+            retryable = false;
+        } else {
+            // 5xx
+            success = false;
+            retryable = true;
+        }
+
+        const deliveryAttempt: DeliveryAttempt = {
+            attemptNumber,
+            timestamp: new Date().toISOString(),
+            httpStatus,
+            durationMs,
+        };
+
+        const updatedAttempts = [...record.attempts, deliveryAttempt];
+
+        await updateRecord(record.id, {
+            attemptCount: attemptNumber,
+            attempts: updatedAttempts,
+        });
+
+        console.log(
+            JSON.stringify({
+                requestId: randomUUID(),
+                timestamp: new Date().toISOString(),
+                event: "webhook.attempt",
+                deliveryId: record.id,
+                attemptNumber,
+                destinationUrl: record.destinationUrl,
+                httpStatus,
+                durationMs,
+                success,
+                retryable,
+            }),
+        );
+
+        return { success, retryable, httpStatus, durationMs };
+    } catch (err) {
+        const durationMs = Date.now() - startTime;
+        errorType = isTimeoutError(err) ? "TIMEOUT" : "NETWORK_ERROR";
+        retryable = true;
+
+        const deliveryAttempt: DeliveryAttempt = {
+            attemptNumber,
+            timestamp: new Date().toISOString(),
+            errorType,
+            durationMs,
+        };
+
+        const updatedAttempts = [...record.attempts, deliveryAttempt];
+
+        await updateRecord(record.id, {
+            attemptCount: attemptNumber,
+            attempts: updatedAttempts,
+        });
+
+        console.log(
+            JSON.stringify({
+                requestId: randomUUID(),
+                timestamp: new Date().toISOString(),
+                event: "webhook.attempt",
+                deliveryId: record.id,
+                attemptNumber,
+                destinationUrl: record.destinationUrl,
+                errorType,
+                durationMs,
+                success: false,
+                retryable: true,
+                error: err instanceof Error ? err.message : String(err),
+            }),
+        );
+
+        return { success: false, retryable: true, errorType, durationMs };
+    }
+}
+
+/**
+ * Mark a record as successfully delivered.
+ */
+export async function markDelivered(recordId: string, attemptCount: number): Promise<void> {
+    await updateRecord(recordId, {
+        status: "delivered",
+        attemptCount,
+        nextAttemptAt: null,
+    });
+
+    console.log(
+        JSON.stringify({
+            requestId: randomUUID(),
+            timestamp: new Date().toISOString(),
+            event: "webhook.delivered",
+            deliveryId: recordId,
+            attemptCount,
+        }),
+    );
+}
+
+/**
+ * Mark a record as permanently failed and clear the next retry time.
+ */
+export async function markFailed(record: DeliveryRecord): Promise<void> {
+    await updateRecord(record.id, {
+        status: "failed",
+        nextAttemptAt: null,
+    });
+
+    console.log(
+        JSON.stringify({
+            requestId: randomUUID(),
+            timestamp: new Date().toISOString(),
+            event: "webhook.failed",
+            deliveryId: record.id,
+            destinationUrl: record.destinationUrl,
+            attemptCount: record.attemptCount,
+        }),
+    );
+}
+
+function isTimeoutError(err: unknown): boolean {
+    if (err instanceof Error) {
+        const msg = err.message.toLowerCase();
+        return msg.includes("timeout") || msg.includes("timed out") || err.name === "AbortError";
+    }
+    return false;
+}

--- a/src/lib/webhook/dlq.ts
+++ b/src/lib/webhook/dlq.ts
@@ -1,0 +1,141 @@
+import { randomUUID } from "crypto";
+import { pool } from "../db/client";
+import { createRecord } from "./delivery-store";
+import type { DeliveryRecord, DLQEntry, WebhookPayload, DeliveryAttempt } from "./types";
+
+export class DLQError extends Error {
+    constructor(
+        message: string,
+        public readonly cause: unknown,
+    ) {
+        super(message);
+        this.name = "DLQError";
+    }
+}
+
+/** Creates the dlq_entries table if it does not already exist. */
+export async function createTable(): Promise<void> {
+    const sql = `
+        CREATE TABLE IF NOT EXISTS dlq_entries (
+            id TEXT PRIMARY KEY,
+            delivery_id TEXT NOT NULL,
+            destination_url TEXT NOT NULL,
+            payload JSONB NOT NULL,
+            attempts JSONB NOT NULL,
+            final_error TEXT NOT NULL,
+            added_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            expires_at TIMESTAMPTZ NOT NULL
+        )
+    `;
+    try {
+        await pool.query(sql);
+    } catch (err) {
+        throw new DLQError("Failed to create dlq_entries table", err);
+    }
+}
+
+function rowToEntry(row: Record<string, unknown>): DLQEntry {
+    return {
+        id: row.id as string,
+        deliveryId: row.delivery_id as string,
+        destinationUrl: row.destination_url as string,
+        payload: row.payload as WebhookPayload,
+        attempts: (row.attempts as DeliveryAttempt[]) ?? [],
+        finalError: row.final_error as string,
+        addedAt: (row.added_at as Date).toISOString(),
+        expiresAt: (row.expires_at as Date).toISOString(),
+    };
+}
+
+/**
+ * Write a failed DeliveryRecord to the DLQ.
+ * expiresAt is set to addedAt + 30 days.
+ * If the write fails, the full DeliveryRecord is logged at error severity.
+ */
+export async function write(record: DeliveryRecord): Promise<DLQEntry> {
+    const id = randomUUID();
+    const finalError =
+        record.attempts.length > 0
+            ? (record.attempts[record.attempts.length - 1].errorType ?? "UNKNOWN_ERROR")
+            : "UNKNOWN_ERROR";
+
+    const sql = `
+        INSERT INTO dlq_entries
+            (id, delivery_id, destination_url, payload, attempts, final_error, added_at, expires_at)
+        VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW() + INTERVAL '30 days')
+        RETURNING *
+    `;
+    try {
+        const result = await pool.query(sql, [
+            id,
+            record.id,
+            record.destinationUrl,
+            JSON.stringify(record.payload),
+            JSON.stringify(record.attempts),
+            finalError,
+        ]);
+        return rowToEntry(result.rows[0]);
+    } catch (err) {
+        console.error("Failed to write DLQ entry", { record: JSON.stringify(record), error: err });
+        throw new DLQError("Failed to write DLQ entry", err);
+    }
+}
+
+/** Retrieve a DLQ entry by delivery ID. Returns null if not found. */
+export async function get(deliveryId: string): Promise<DLQEntry | null> {
+    const sql = `SELECT * FROM dlq_entries WHERE delivery_id = $1`;
+    try {
+        const result = await pool.query(sql, [deliveryId]);
+        if (result.rows.length === 0) return null;
+        return rowToEntry(result.rows[0]);
+    } catch (err) {
+        throw new DLQError(`Failed to get DLQ entry for delivery ${deliveryId}`, err);
+    }
+}
+
+/**
+ * Replay a DLQ entry: creates a new DeliveryRecord with attemptCount = 0,
+ * status = 'pending', and a new UUID id.
+ */
+export async function replay(entryId: string): Promise<DeliveryRecord> {
+    const sql = `SELECT * FROM dlq_entries WHERE id = $1`;
+    let entry: DLQEntry;
+    try {
+        const result = await pool.query(sql, [entryId]);
+        if (result.rows.length === 0) {
+            throw new DLQError(`DLQ entry ${entryId} not found`, null);
+        }
+        entry = rowToEntry(result.rows[0]);
+    } catch (err) {
+        if (err instanceof DLQError) throw err;
+        throw new DLQError(`Failed to fetch DLQ entry ${entryId}`, err);
+    }
+
+    return createRecord(entry.destinationUrl, entry.payload);
+}
+
+/** List DLQ entries, optionally filtered by destinationUrl and/or since date. */
+export async function list(filter?: { destinationUrl?: string; since?: Date }): Promise<DLQEntry[]> {
+    const conditions: string[] = [];
+    const values: unknown[] = [];
+    let paramIndex = 1;
+
+    if (filter?.destinationUrl) {
+        conditions.push(`destination_url = $${paramIndex++}`);
+        values.push(filter.destinationUrl);
+    }
+    if (filter?.since) {
+        conditions.push(`added_at >= $${paramIndex++}`);
+        values.push(filter.since);
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+    const sql = `SELECT * FROM dlq_entries ${where} ORDER BY added_at DESC`;
+
+    try {
+        const result = await pool.query(sql, values);
+        return result.rows.map(rowToEntry);
+    } catch (err) {
+        throw new DLQError("Failed to list DLQ entries", err);
+    }
+}

--- a/src/lib/webhook/retry-scheduler.ts
+++ b/src/lib/webhook/retry-scheduler.ts
@@ -1,0 +1,60 @@
+import type { DeliveryRecord } from "./types";
+import { getWebhookConfig } from "./config";
+
+export interface RetryScheduler {
+    calculateBackoff(attemptNumber: number, retryAfterSeconds?: number): number;
+    scheduleNext(record: DeliveryRecord): Promise<DeliveryRecord>;
+    hasRemainingAttempts(record: DeliveryRecord): boolean;
+}
+
+/**
+ * Calculates the backoff interval in milliseconds for a given attempt number.
+ *
+ * Formula: base * 2^(n-1) + random jitter up to 25%
+ * If retryAfterSeconds is provided (from a 429 Retry-After header), it is used
+ * as the base interval instead of the exponential formula (Property 6).
+ */
+export function calculateBackoff(attemptNumber: number, retryAfterSeconds?: number): number {
+    const config = getWebhookConfig();
+    const { baseDelaySeconds, jitterFactor } = config;
+
+    let baseMs: number;
+    if (retryAfterSeconds !== undefined && retryAfterSeconds > 0) {
+        // Property 6: respect Retry-After header value
+        baseMs = retryAfterSeconds * 1000;
+    } else {
+        // Property 1: base * 2^(n-1)
+        baseMs = baseDelaySeconds * Math.pow(2, attemptNumber - 1) * 1000;
+    }
+
+    // Property 2: add random jitter up to 25%
+    const jitter = Math.random() * jitterFactor * baseMs;
+    return baseMs + jitter;
+}
+
+/**
+ * Returns true if the record has remaining retry attempts available.
+ */
+export function hasRemainingAttempts(record: DeliveryRecord): boolean {
+    return record.attemptCount < record.maxAttempts;
+}
+
+/**
+ * Schedules the next attempt by updating nextAttemptAt on the record.
+ * Uses the current attemptCount to determine the backoff interval.
+ */
+export async function scheduleNext(record: DeliveryRecord): Promise<DeliveryRecord> {
+    const delayMs = calculateBackoff(record.attemptCount);
+    const nextAttemptAt = new Date(Date.now() + delayMs).toISOString();
+    return {
+        ...record,
+        nextAttemptAt,
+        updatedAt: new Date().toISOString(),
+    };
+}
+
+export const retryScheduler: RetryScheduler = {
+    calculateBackoff,
+    scheduleNext,
+    hasRemainingAttempts,
+};

--- a/src/lib/webhook/types.ts
+++ b/src/lib/webhook/types.ts
@@ -1,0 +1,48 @@
+export type DeliveryStatus = "pending" | "delivered" | "failed";
+
+export interface DeliveryAttempt {
+    attemptNumber: number; // 1-based
+    timestamp: string; // ISO 8601
+    httpStatus?: number; // undefined for network errors
+    errorType?: string; // e.g. 'NETWORK_ERROR', 'TIMEOUT'
+    durationMs: number;
+}
+
+export interface WebhookPayload {
+    headers: Record<string, string>; // original inbound headers (sensitive values redacted)
+    body: string; // raw body string
+    source: string; // e.g. 'paycrest'
+}
+
+export interface DeliveryRecord {
+    id: string; // UUID, unique delivery ID
+    destinationUrl: string;
+    payload: WebhookPayload;
+    status: DeliveryStatus;
+    attemptCount: number; // total attempts made so far
+    maxAttempts: number; // from config, default 5
+    attempts: DeliveryAttempt[];
+    nextAttemptAt: string | null; // ISO 8601, null when delivered/failed
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface DLQEntry {
+    id: string; // UUID
+    deliveryId: string; // references DeliveryRecord.id
+    destinationUrl: string;
+    payload: WebhookPayload;
+    attempts: DeliveryAttempt[];
+    finalError: string;
+    addedAt: string; // ISO 8601
+    expiresAt: string; // ISO 8601, addedAt + 30 days
+}
+
+export interface WebhookRetryConfig {
+    baseDelaySeconds: number; // WEBHOOK_RETRY_BASE_DELAY_SECONDS, default 30
+    maxAttempts: number; // WEBHOOK_RETRY_MAX_ATTEMPTS, default 5
+    jitterFactor: number; // fixed at 0.25 (25%)
+    alertChannelUrl: string; // WEBHOOK_ALERT_CHANNEL_URL (Slack webhook or email endpoint)
+    alertSuppressionSeconds: number; // WEBHOOK_ALERT_SUPPRESSION_SECONDS, default 300
+    dlqRetentionDays: number; // fixed at 30
+}


### PR DESCRIPTION
## feat: backend infrastructure improvements

Implements four backend infrastructure improvements to enhance reliability,
performance, compatibility, and data durability.

### Changes

**Webhook Retry Mechanism**
- Exponential backoff with jitter (30s base, configurable via env)
- Max retry limit (5 attempts, configurable) with smart 4xx/429 handling
- Structured retry attempt logging with unique delivery IDs
- Dead letter queue with 30-day retention and manual replay support
- Aggregated failure alerts with 5-minute window deduplication
- Cron retry runner at `/api/webhooks/retry-runner`

**Transaction Status Polling Optimization**
- Exponential backoff for polling (2s base → 30s max with jitter)
- WebSocket-first delivery with HTTP polling fallback
- Server-side status caching (3s TTL, 60s terminal state retention)
- Request deduplication and page visibility pausing
- Per-request (8s) and session-level (5/10 min) timeout handling
- Refactored `usePollBridgeStatus` and `usePollPayoutStatus` — public APIs unchanged

**API Versioning**
- `/api/v1/` prefix for all 16 public routes (thin re-exports, no logic duplication)
- Version negotiation via URL prefix, `X-API-Version` header, and `Accept` header
- `Deprecation`, `Sunset`, and `Link` headers on legacy unversioned routes
- `GET /api/versions` metadata endpoint
- Migration guide at `docs/api-migration-v1.md`

**Database for Transaction History**
- PostgreSQL schema with `transactions` table, status constraint, and indexes
- Idempotent migration at `migrations/001_create_transactions.sql`
- Typed DAL (`src/lib/db/dal.ts`) with parameterised queries
- `GET /api/transactions`, `POST /api/transactions`, `PATCH /api/transactions/[id]`
- Webhook handler updated to persist status changes via DAL
- History page migrated from `localStorage` to server-side API
- Offramp initiation persists a pending transaction with UUID v4 id
- `DATABASE_URL` environment variable (added to `.env.example`)

Closes #268
Closes #269
Closes #270
Closes #271