### PR TITLE
test: add integration tests for API endpoints

### DIFF
--- a/src/test/integration/bridge-build-tx.integration.test.ts
+++ b/src/test/integration/bridge-build-tx.integration.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ── Env mock ──────────────────────────────────────────────────────────────────
+vi.mock('@/lib/env', () => ({
+  env: {
+    server: {
+      PAYCREST_API_KEY: 'test-api-key',
+      PAYCREST_WEBHOOK_SECRET: 'test-secret',
+      BASE_PRIVATE_KEY: '0xdeadbeef',
+      BASE_RETURN_ADDRESS: '0xreturn',
+      BASE_RPC_URL: 'https://base-rpc.test',
+      STELLAR_SOROBAN_RPC_URL: 'https://soroban.test',
+      STELLAR_HORIZON_URL: 'https://horizon.test',
+    },
+    public: {
+      NEXT_PUBLIC_STELLAR_SOROBAN_RPC_URL: 'https://soroban.test',
+      NEXT_PUBLIC_BASE_RETURN_ADDRESS: '0xreturn',
+      NEXT_PUBLIC_STELLAR_USDC_ISSUER: 'GISSUER',
+    },
+  },
+}));
+
+// ── Rate limiter mock (always allow) ─────────────────────────────────────────
+vi.mock('@/lib/offramp/utils/rate-limiter', () => ({
+  buildTxLimiter: { check: vi.fn().mockReturnValue({ allowed: true }) },
+  getClientIp: vi.fn().mockReturnValue('127.0.0.1'),
+}));
+
+// ── Validation mock ───────────────────────────────────────────────────────────
+vi.mock('@/lib/offramp/utils/validation', () => ({
+  validateAmount: vi.fn(),
+  validateAddress: vi.fn(),
+}));
+
+// ── Allbridge SDK mock ────────────────────────────────────────────────────────
+const mockSend = vi.fn();
+const mockGetGasFeeOptions = vi.fn();
+const mockChainDetailsMap = vi.fn();
+
+const FAKE_SOURCE_TOKEN = { symbol: 'USDC', decimals: 7, contract: '0xsrc', chain: 'STELLAR' };
+const FAKE_DEST_TOKEN = { symbol: 'USDC', decimals: 6, contract: '0xdst', chain: 'BASE' };
+
+vi.mock('@allbridge/bridge-core-sdk', () => ({
+  AllbridgeCoreSdk: class {
+    chainDetailsMap = mockChainDetailsMap;
+    getGasFeeOptions = mockGetGasFeeOptions;
+    bridge = { rawTxBuilder: { send: mockSend } };
+  },
+  nodeRpcUrlsDefault: {},
+  Messenger: { ALLBRIDGE: 'ALLBRIDGE' },
+  FeePaymentMethod: {
+    WITH_STABLECOIN: 'WITH_STABLECOIN',
+    WITH_NATIVE_CURRENCY: 'WITH_NATIVE_CURRENCY',
+  },
+}));
+
+import { POST } from '@/app/api/offramp/bridge/build-tx/route';
+import * as validation from '@/lib/offramp/utils/validation';
+import * as rateLimiter from '@/lib/offramp/utils/rate-limiter';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const VALID_STELLAR = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+const VALID_BASE = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+
+function makeReq(body: object): NextRequest {
+  return new NextRequest('http://localhost/api/offramp/bridge/build-tx', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function setupSdkSuccess() {
+  vi.mocked(validation.validateAmount).mockReturnValue(true);
+  vi.mocked(validation.validateAddress).mockReturnValue(true);
+  mockChainDetailsMap.mockResolvedValue({
+    stellar: { name: 'Stellar', tokens: [FAKE_SOURCE_TOKEN] },
+    base: { name: 'Base', tokens: [FAKE_DEST_TOKEN] },
+  });
+  mockGetGasFeeOptions.mockResolvedValue({
+    WITH_STABLECOIN: { float: '0.5' },
+    WITH_NATIVE_CURRENCY: { float: '0.001' },
+  });
+  mockSend.mockResolvedValue('FAKE_XDR_STRING');
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('POST /api/offramp/bridge/build-tx (integration)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns xdr and token info for a valid stablecoin-fee request', async () => {
+    setupSdkSuccess();
+    const res = await POST(makeReq({
+      amount: '10',
+      fromAddress: VALID_STELLAR,
+      toAddress: VALID_BASE,
+      feePaymentMethod: 'stablecoin',
+    }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toMatchObject({
+      xdr: 'FAKE_XDR_STRING',
+      sourceToken: { symbol: 'USDC', chain: 'STELLAR' },
+      destinationToken: { symbol: 'USDC', chain: 'BASE' },
+    });
+  });
+
+  it('returns xdr for native fee method', async () => {
+    setupSdkSuccess();
+    const res = await POST(makeReq({
+      amount: '10',
+      fromAddress: VALID_STELLAR,
+      toAddress: VALID_BASE,
+      feePaymentMethod: 'native',
+    }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.xdr).toBe('FAKE_XDR_STRING');
+  });
+
+  it('defaults to stablecoin fee when feePaymentMethod is omitted', async () => {
+    setupSdkSuccess();
+    const res = await POST(makeReq({ amount: '10', fromAddress: VALID_STELLAR, toAddress: VALID_BASE }));
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 400 for invalid amount', async () => {
+    vi.mocked(validation.validateAmount).mockReturnValue(false);
+    const res = await POST(makeReq({ amount: '-5', fromAddress: VALID_STELLAR, toAddress: VALID_BASE }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/amount/i);
+  });
+
+  it('returns 400 for invalid Stellar address', async () => {
+    vi.mocked(validation.validateAmount).mockReturnValue(true);
+    vi.mocked(validation.validateAddress).mockImplementation((_addr, chain) => chain !== 'stellar');
+    const res = await POST(makeReq({ amount: '10', fromAddress: 'bad-addr', toAddress: VALID_BASE }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/stellar/i);
+  });
+
+  it('returns 400 for invalid Base address', async () => {
+    vi.mocked(validation.validateAmount).mockReturnValue(true);
+    vi.mocked(validation.validateAddress).mockImplementation((_addr, chain) => chain !== 'base');
+    const res = await POST(makeReq({ amount: '10', fromAddress: VALID_STELLAR, toAddress: 'bad-addr' }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/base/i);
+  });
+
+  it('returns 400 for invalid feePaymentMethod', async () => {
+    vi.mocked(validation.validateAmount).mockReturnValue(true);
+    vi.mocked(validation.validateAddress).mockReturnValue(true);
+    const res = await POST(makeReq({
+      amount: '10',
+      fromAddress: VALID_STELLAR,
+      toAddress: VALID_BASE,
+      feePaymentMethod: 'bitcoin',
+    }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/feePaymentMethod/i);
+  });
+
+  it('returns 429 when rate limit is exceeded', async () => {
+    vi.mocked(rateLimiter.buildTxLimiter.check).mockReturnValueOnce({ allowed: false, retryAfter: 60 } as any);
+    const res = await POST(makeReq({ amount: '10', fromAddress: VALID_STELLAR, toAddress: VALID_BASE }));
+    expect(res.status).toBe(429);
+  });
+
+  it('returns 500 when chain details are unavailable', async () => {
+    vi.mocked(validation.validateAmount).mockReturnValue(true);
+    vi.mocked(validation.validateAddress).mockReturnValue(true);
+    mockChainDetailsMap.mockResolvedValue({});
+    const res = await POST(makeReq({ amount: '10', fromAddress: VALID_STELLAR, toAddress: VALID_BASE }));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/chain details/i);
+  });
+
+  it('returns 500 with user-friendly message for insufficient balance error', async () => {
+    setupSdkSuccess();
+    mockSend.mockRejectedValue(new Error('resulting balance is not within the allowed range'));
+    const res = await POST(makeReq({ amount: '10', fromAddress: VALID_STELLAR, toAddress: VALID_BASE }));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/xlm/i);
+  });
+});

--- a/src/test/integration/execute-payout.integration.test.ts
+++ b/src/test/integration/execute-payout.integration.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+vi.mock('@/lib/db/dal', () => ({
+  dal: { save: vi.fn() },
+}));
+
+// ── Fee calculation mock ──────────────────────────────────────────────────────
+vi.mock('@/lib/fee-calculation', () => ({
+  calculateAllFees: vi.fn().mockResolvedValue({
+    bridgeFee: '0.5',
+    networkFee: '0.1',
+    paycrestFee: '0',
+    totalFee: '0.6',
+  }),
+}));
+
+// ── Idempotency mock (pass-through) ───────────────────────────────────────────
+vi.mock('@/lib/idempotency', () => ({
+  withIdempotency: async (_req: NextRequest, handler: () => Promise<Response>) => handler(),
+}));
+
+import { POST } from '@/app/api/offramp/execute-payout/route';
+import { dal } from '@/lib/db/dal';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const VALID_BODY = {
+  userAddress: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  amount: '100',
+  currency: 'NGN',
+  feeMethod: 'USDC',
+  receiveAmount: '99.5',
+  beneficiary: {
+    institution: 'ACCESS',
+    accountIdentifier: '1234567890',
+    accountName: 'John Doe',
+    currency: 'NGN',
+  },
+};
+
+function makeReq(body: object): NextRequest {
+  return new NextRequest('http://localhost/api/offramp/execute-payout', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('POST /api/offramp/execute-payout (integration)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(dal.save).mockResolvedValue(undefined);
+  });
+
+  it('creates a transaction and returns { id, status: "pending" }', async () => {
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toMatchObject({ id: expect.any(String), status: 'pending' });
+    expect(dal.save).toHaveBeenCalledOnce();
+  });
+
+  it('saves transaction with correct fields', async () => {
+    await POST(makeReq(VALID_BODY));
+    const saved = vi.mocked(dal.save).mock.calls[0][0];
+    expect(saved).toMatchObject({
+      userAddress: VALID_BODY.userAddress,
+      amount: VALID_BODY.amount,
+      currency: VALID_BODY.currency,
+      status: 'pending',
+      beneficiary: VALID_BODY.beneficiary,
+    });
+  });
+
+  it('normalizes USDC feeMethod to stablecoin', async () => {
+    await POST(makeReq({ ...VALID_BODY, feeMethod: 'USDC' }));
+    const saved = vi.mocked(dal.save).mock.calls[0][0];
+    expect(saved.feeMethod).toBe('stablecoin');
+  });
+
+  it('normalizes XLM feeMethod to native', async () => {
+    await POST(makeReq({ ...VALID_BODY, feeMethod: 'XLM' }));
+    const saved = vi.mocked(dal.save).mock.calls[0][0];
+    expect(saved.feeMethod).toBe('native');
+  });
+
+  it('returns 400 when userAddress is missing', async () => {
+    const { userAddress: _, ...body } = VALID_BODY;
+    const res = await POST(makeReq(body));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/missing required fields/i);
+  });
+
+  it('returns 400 when amount is missing', async () => {
+    const { amount: _, ...body } = VALID_BODY;
+    const res = await POST(makeReq(body));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/missing required fields/i);
+  });
+
+  it('returns 400 when beneficiary is missing', async () => {
+    const { beneficiary: _, ...body } = VALID_BODY;
+    const res = await POST(makeReq(body));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/missing required fields/i);
+  });
+
+  it('returns 400 for malformed JSON body', async () => {
+    const req = new NextRequest('http://localhost/api/offramp/execute-payout', {
+      method: 'POST',
+      body: 'not-json',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/invalid request body/i);
+  });
+
+  it('returns 500 when DB save fails', async () => {
+    vi.mocked(dal.save).mockRejectedValue(new Error('DB connection failed'));
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/internal server error/i);
+  });
+
+  it('skips fee calculation when feeMethod is not provided', async () => {
+    const { feeMethod: _, ...body } = VALID_BODY;
+    await POST(makeReq(body));
+    const saved = vi.mocked(dal.save).mock.calls[0][0];
+    expect(saved.feeMethod).toBeUndefined();
+    expect(saved.totalFee).toBeUndefined();
+  });
+});

--- a/src/test/integration/paycrest-order.integration.test.ts
+++ b/src/test/integration/paycrest-order.integration.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ── Env mock ──────────────────────────────────────────────────────────────────
+vi.mock('@/lib/env', () => ({
+  env: {
+    server: {
+      PAYCREST_API_KEY: 'test-api-key',
+      PAYCREST_WEBHOOK_SECRET: 'test-secret',
+      BASE_PRIVATE_KEY: '0xdeadbeef',
+      BASE_RETURN_ADDRESS: '0xreturn',
+      BASE_RPC_URL: 'https://base-rpc.test',
+      STELLAR_SOROBAN_RPC_URL: 'https://soroban.test',
+      STELLAR_HORIZON_URL: 'https://horizon.test',
+    },
+    public: {
+      NEXT_PUBLIC_STELLAR_SOROBAN_RPC_URL: 'https://soroban.test',
+      NEXT_PUBLIC_BASE_RETURN_ADDRESS: '0xreturn',
+      NEXT_PUBLIC_STELLAR_USDC_ISSUER: 'GISSUER',
+    },
+  },
+}));
+
+// ── Rate limiter mock (always allow) ─────────────────────────────────────────
+vi.mock('@/lib/offramp/utils/rate-limiter', () => ({
+  paycrestOrderLimiter: { check: vi.fn().mockReturnValue({ allowed: true }) },
+  getClientIp: vi.fn().mockReturnValue('127.0.0.1'),
+}));
+
+// ── Idempotency mock (pass-through) ───────────────────────────────────────────
+vi.mock('@/lib/idempotency', () => ({
+  withIdempotency: async (_req: NextRequest, handler: () => Promise<Response>) => handler(),
+}));
+
+// ── PaycrestAdapter mock ──────────────────────────────────────────────────────
+const mockCreateOrder = vi.fn();
+
+vi.mock('@/lib/offramp/adapters/paycrest-adapter', () => ({
+  PaycrestAdapter: class {
+    createOrder = mockCreateOrder;
+  },
+  PaycrestHttpError: class extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = 'PaycrestHttpError';
+      this.status = status;
+    }
+  },
+}));
+
+import { POST } from '@/app/api/offramp/paycrest/order/route';
+import { PaycrestHttpError } from '@/lib/offramp/adapters/paycrest-adapter';
+import * as rateLimiter from '@/lib/offramp/utils/rate-limiter';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const VALID_BODY = {
+  amount: 100,
+  rate: 1600,
+  token: 'USDC',
+  network: 'stellar',
+  reference: 'ref-001',
+  returnAddress: '0xreturnAddress',
+  recipient: {
+    institution: 'ACCESS',
+    accountIdentifier: '1234567890',
+    accountName: 'John Doe',
+    currency: 'NGN',
+  },
+};
+
+function makeReq(body: object): NextRequest {
+  return new NextRequest('http://localhost/api/offramp/paycrest/order', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('POST /api/offramp/paycrest/order (integration)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('creates order and returns { data: { id, receiveAddress } }', async () => {
+    mockCreateOrder.mockResolvedValue({ id: 'order-1', receiveAddress: '0xabc123' });
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data).toMatchObject({ id: 'order-1', receiveAddress: '0xabc123' });
+  });
+
+  it('calls PaycrestAdapter.createOrder with normalized values', async () => {
+    mockCreateOrder.mockResolvedValue({ id: 'order-2', receiveAddress: '0xdef' });
+    await POST(makeReq(VALID_BODY));
+    expect(mockCreateOrder).toHaveBeenCalledOnce();
+    const args = mockCreateOrder.mock.calls[0][0];
+    expect(args.amount).toBe(100);
+    expect(args.rate).toBe(1600);
+    expect(args.token).toBe('USDC');
+    expect(args.recipient.institution).toBe('ACCESS');
+  });
+
+  it('returns 400 when amount is missing', async () => {
+    const { amount: _, ...body } = VALID_BODY;
+    const res = await POST(makeReq(body));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.details).toHaveProperty('amount');
+  });
+
+  it('returns 400 when amount is not a positive number', async () => {
+    const res = await POST(makeReq({ ...VALID_BODY, amount: -5 }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.details.amount).toMatch(/positive/i);
+  });
+
+  it('returns 400 when rate is missing', async () => {
+    const { rate: _, ...body } = VALID_BODY;
+    const res = await POST(makeReq(body));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.details).toHaveProperty('rate');
+  });
+
+  it('returns 400 when token is missing', async () => {
+    const { token: _, ...body } = VALID_BODY;
+    const res = await POST(makeReq(body));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.details).toHaveProperty('token');
+  });
+
+  it('returns 400 when recipient is missing', async () => {
+    const { recipient: _, ...body } = VALID_BODY;
+    const res = await POST(makeReq(body));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.details).toHaveProperty('recipient');
+  });
+
+  it('returns 400 when recipient.institution is empty', async () => {
+    const body = { ...VALID_BODY, recipient: { ...VALID_BODY.recipient, institution: '' } };
+    const res = await POST(makeReq(body));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.details).toHaveProperty('recipient.institution');
+  });
+
+  it('returns 400 when recipient.accountIdentifier is missing', async () => {
+    const body = {
+      ...VALID_BODY,
+      recipient: { ...VALID_BODY.recipient, accountIdentifier: '' },
+    };
+    const res = await POST(makeReq(body));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.details).toHaveProperty('recipient.accountIdentifier');
+  });
+
+  it('returns 429 when rate limit is exceeded', async () => {
+    vi.mocked(rateLimiter.paycrestOrderLimiter.check).mockReturnValueOnce({ allowed: false, retryAfter: 30 } as any);
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBe('30');
+  });
+
+  it('propagates Paycrest HTTP 401 error', async () => {
+    mockCreateOrder.mockRejectedValue(new PaycrestHttpError('Unauthorized', 401));
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(401);
+  });
+
+  it('propagates Paycrest HTTP 422 error', async () => {
+    mockCreateOrder.mockRejectedValue(new PaycrestHttpError('Unprocessable Entity', 422));
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 500 for unexpected errors', async () => {
+    mockCreateOrder.mockRejectedValue(new Error('Network timeout'));
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/test/integration/quote.integration.test.ts
+++ b/src/test/integration/quote.integration.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ── Env mock ──────────────────────────────────────────────────────────────────
+vi.mock('@/lib/env', () => ({
+  env: {
+    server: {
+      PAYCREST_API_KEY: 'test-api-key',
+      PAYCREST_WEBHOOK_SECRET: 'test-secret',
+      BASE_PRIVATE_KEY: '0xdeadbeef',
+      BASE_RETURN_ADDRESS: '0xreturn',
+      BASE_RPC_URL: 'https://base-rpc.test',
+      STELLAR_SOROBAN_RPC_URL: 'https://soroban.test',
+      STELLAR_HORIZON_URL: 'https://horizon.test',
+    },
+    public: {
+      NEXT_PUBLIC_STELLAR_SOROBAN_RPC_URL: 'https://soroban.test',
+      NEXT_PUBLIC_BASE_RETURN_ADDRESS: '0xreturn',
+      NEXT_PUBLIC_STELLAR_USDC_ISSUER: 'GISSUER',
+    },
+  },
+}));
+
+// ── Currency support mock ─────────────────────────────────────────────────────
+vi.mock('@/lib/currencies', () => ({
+  isSupportedCurrency: (c: string) => ['NGN', 'KES', 'GHS'].includes(c),
+}));
+
+// ── Validation mock ───────────────────────────────────────────────────────────
+vi.mock('@/lib/offramp/utils/validation', () => ({
+  validateAmount: (v: string) => parseFloat(v) > 0,
+}));
+
+// ── Quote utilities mock ──────────────────────────────────────────────────────
+vi.mock('@/lib/offramp/utils/quote-fetcher', () => ({
+  fetchPaycrestQuote: vi.fn(),
+  buildQuote: vi.fn(),
+  calculateBridgeAmount: vi.fn(),
+}));
+
+// ── Allbridge SDK mock ────────────────────────────────────────────────────────
+const mockGetAmountToBeReceived = vi.fn();
+const mockChainDetailsMap = vi.fn();
+
+vi.mock('@allbridge/bridge-core-sdk', () => ({
+  AllbridgeCoreSdk: class {
+    chainDetailsMap = mockChainDetailsMap;
+    getAmountToBeReceived = mockGetAmountToBeReceived;
+  },
+  nodeRpcUrlsDefault: {},
+}));
+
+// ── Timeout wrapper mock (pass-through) ───────────────────────────────────────
+vi.mock('@/lib/offramp/utils/timeout', () => ({
+  withAllbridgeTimeout: async (_fn: () => Promise<unknown>) => _fn(),
+}));
+
+// ── Error handler mock ────────────────────────────────────────────────────────
+vi.mock('@/lib/error-handler', () => ({
+  ErrorHandler: { serverError: vi.fn() },
+}));
+
+import { POST } from '@/app/api/offramp/quote/route';
+import * as quoteFetcher from '@/lib/offramp/utils/quote-fetcher';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeReq(body: object): NextRequest {
+  return new NextRequest('http://localhost/api/offramp/quote', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const STELLAR_USDC = { symbol: 'USDC', decimals: 7, chain: 'STELLAR' };
+const BASE_USDC = { symbol: 'USDC', decimals: 6, chain: 'BASE' };
+
+function setupSdkSuccess() {
+  mockChainDetailsMap.mockResolvedValue({
+    stellar: { name: 'Stellar', tokens: [STELLAR_USDC] },
+    base: { name: 'Base Ethereum', tokens: [BASE_USDC] },
+  });
+  mockGetAmountToBeReceived.mockResolvedValue('99.5');
+  vi.mocked(quoteFetcher.calculateBridgeAmount).mockReturnValue('99.5');
+  vi.mocked(quoteFetcher.fetchPaycrestQuote).mockResolvedValue({ rate: 1600, destinationAmount: '159200.00' });
+  vi.mocked(quoteFetcher.buildQuote).mockReturnValue({
+    destinationAmount: '159200.00',
+    rate: 1600,
+    currency: 'NGN',
+    bridgeFee: '0.5',
+    payoutFee: '0',
+    estimatedTime: 300,
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('POST /api/offramp/quote (integration)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a valid quote for a supported currency with USDC fee', async () => {
+    setupSdkSuccess();
+    const res = await POST(makeReq({ amount: '100', currency: 'NGN', feeMethod: 'USDC' }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toMatchObject({
+      destinationAmount: expect.any(String),
+      rate: expect.any(Number),
+      currency: 'NGN',
+    });
+  });
+
+  it('returns a valid quote with XLM fee method', async () => {
+    setupSdkSuccess();
+    vi.mocked(quoteFetcher.buildQuote).mockReturnValue({
+      destinationAmount: '80000.00',
+      rate: 1600,
+      currency: 'KES',
+      bridgeFee: '0',
+      payoutFee: '0',
+      estimatedTime: 300,
+    });
+    const res = await POST(makeReq({ amount: '50', currency: 'KES', feeMethod: 'XLM' }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.currency).toBe('KES');
+  });
+
+  it('returns 400 for invalid amount', async () => {
+    const res = await POST(makeReq({ amount: '-10', currency: 'NGN', feeMethod: 'USDC' }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/amount/i);
+  });
+
+  it('returns 400 for missing currency', async () => {
+    const res = await POST(makeReq({ amount: '100', feeMethod: 'USDC' }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/currency/i);
+  });
+
+  it('returns 400 for unsupported currency', async () => {
+    const res = await POST(makeReq({ amount: '100', currency: 'XYZ', feeMethod: 'USDC' }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/unsupported/i);
+  });
+
+  it('returns 400 for invalid feeMethod', async () => {
+    const res = await POST(makeReq({ amount: '100', currency: 'NGN', feeMethod: 'BTC' }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/feeMethod/i);
+  });
+
+  it('returns 502 when Allbridge SDK fails', async () => {
+    vi.mocked(quoteFetcher.calculateBridgeAmount).mockReturnValue('99.5');
+    mockChainDetailsMap.mockRejectedValue(new Error('Network error'));
+    const res = await POST(makeReq({ amount: '100', currency: 'NGN', feeMethod: 'USDC' }));
+    expect(res.status).toBe(502);
+    const json = await res.json();
+    expect(json.error).toMatch(/bridge quote unavailable/i);
+  });
+
+  it('returns 502 when Paycrest FX rate fetch fails', async () => {
+    setupSdkSuccess();
+    vi.mocked(quoteFetcher.fetchPaycrestQuote).mockRejectedValue(new Error('Paycrest down'));
+    const res = await POST(makeReq({ amount: '100', currency: 'NGN', feeMethod: 'USDC' }));
+    expect(res.status).toBe(502);
+    const json = await res.json();
+    expect(json.error).toMatch(/fx rate unavailable/i);
+  });
+});

--- a/src/test/integration/webhook-paycrest.integration.test.ts
+++ b/src/test/integration/webhook-paycrest.integration.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+vi.mock('@/lib/db/dal', () => ({
+  dal: {
+    getByPayoutOrderId: vi.fn(),
+    update: vi.fn(),
+    getById: vi.fn(),
+  },
+  DatabaseError: class DatabaseError extends Error {},
+}));
+
+// ── Webhook dispatcher mock ───────────────────────────────────────────────────
+vi.mock('@/lib/webhook/dispatcher', () => ({
+  enqueue: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ── Notification service mock ─────────────────────────────────────────────────
+vi.mock('@/lib/notifications/service', () => ({
+  notifyTransactionStatusUpdate: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ── Env mock ──────────────────────────────────────────────────────────────────
+vi.mock('@/lib/env', () => ({
+  env: {
+    server: {
+      PAYCREST_WEBHOOK_SECRET: 'test-webhook-secret',
+      PAYCREST_API_KEY: 'test-api-key',
+      BASE_PRIVATE_KEY: '0xdeadbeef',
+      BASE_RETURN_ADDRESS: '0xreturn',
+      BASE_RPC_URL: 'https://base-rpc.test',
+      STELLAR_SOROBAN_RPC_URL: 'https://soroban.test',
+      STELLAR_HORIZON_URL: 'https://horizon.test',
+    },
+    public: {
+      NEXT_PUBLIC_STELLAR_SOROBAN_RPC_URL: 'https://soroban.test',
+      NEXT_PUBLIC_BASE_RETURN_ADDRESS: '0xreturn',
+      NEXT_PUBLIC_STELLAR_USDC_ISSUER: 'GISSUER',
+    },
+  },
+}));
+
+import { POST } from '@/app/api/webhooks/paycrest/route';
+import { dal } from '@/lib/db/dal';
+import { notifyTransactionStatusUpdate } from '@/lib/notifications/service';
+import { enqueue } from '@/lib/webhook/dispatcher';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function hmacHex(body: string, secret: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const mac = await crypto.subtle.sign('HMAC', key, enc.encode(body));
+  return Buffer.from(mac).toString('hex');
+}
+
+function makeRequest(body: string, signature: string): Request {
+  return new Request('http://localhost/api/webhooks/paycrest', {
+    method: 'POST',
+    body,
+    headers: { 'X-Paycrest-Signature': signature },
+  });
+}
+
+const FAKE_TRANSACTION = {
+  id: 'tx-1',
+  status: 'pending',
+  payoutStatus: undefined,
+  userAddress: 'GABC',
+  amount: '100',
+  currency: 'NGN',
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('POST /api/webhooks/paycrest (integration)', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Reset all mocks explicitly
+    vi.mocked(dal.getByPayoutOrderId).mockReset().mockResolvedValue(null);
+    vi.mocked(dal.update).mockReset().mockResolvedValue(undefined);
+    vi.mocked(dal.getById).mockReset().mockResolvedValue(FAKE_TRANSACTION as any);
+    vi.mocked(enqueue).mockReset().mockResolvedValue(undefined);
+    vi.mocked(notifyTransactionStatusUpdate).mockReset().mockResolvedValue(undefined);
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it('returns 200 with valid HMAC signature', async () => {
+    const body = JSON.stringify({ event: 'payment_order.settled', data: { id: 'order-200-test' } });
+    const sig = await hmacHex(body, 'test-webhook-secret');
+    const res = await POST(makeRequest(body, sig));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ received: true });
+  });
+
+  it('returns 401 with invalid signature', async () => {
+    const body = JSON.stringify({ event: 'payment_order.settled', data: { id: 'order-1' } });
+    const res = await POST(makeRequest(body, 'invalid-sig'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when signature header is missing', async () => {
+    const body = JSON.stringify({ event: 'payment_order.settled', data: { id: 'order-1' } });
+    const req = new Request('http://localhost/api/webhooks/paycrest', { method: 'POST', body });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('updates transaction to completed on payment_order.settled', async () => {
+    vi.mocked(dal.getByPayoutOrderId).mockResolvedValue(FAKE_TRANSACTION as any);
+    const body = JSON.stringify({ event: 'payment_order.settled', data: { id: 'order-settled-1' } });
+    const sig = await hmacHex(body, 'test-webhook-secret');
+    await POST(makeRequest(body, sig));
+    expect(dal.update).toHaveBeenCalledWith('tx-1', { status: 'completed', payoutStatus: 'settled' });
+  });
+
+  it('updates transaction to failed on payment_order.refunded', async () => {
+    vi.mocked(dal.getByPayoutOrderId).mockResolvedValue(FAKE_TRANSACTION as any);
+    const body = JSON.stringify({ event: 'payment_order.refunded', data: { id: 'order-refunded-1' } });
+    const sig = await hmacHex(body, 'test-webhook-secret');
+    await POST(makeRequest(body, sig));
+    expect(dal.update).toHaveBeenCalledWith('tx-1', expect.objectContaining({
+      status: 'failed',
+      payoutStatus: 'refunded',
+    }));
+  });
+
+  it('updates transaction to failed on payment_order.expired', async () => {
+    vi.mocked(dal.getByPayoutOrderId).mockResolvedValue(FAKE_TRANSACTION as any);
+    const body = JSON.stringify({ event: 'payment_order.expired', data: { id: 'order-expired-1' } });
+    const sig = await hmacHex(body, 'test-webhook-secret');
+    await POST(makeRequest(body, sig));
+    expect(dal.update).toHaveBeenCalledWith('tx-1', expect.objectContaining({
+      status: 'failed',
+      payoutStatus: 'expired',
+    }));
+  });
+
+  it('updates payoutStatus to pending on payment_order.pending', async () => {
+    vi.mocked(dal.getByPayoutOrderId).mockResolvedValue(FAKE_TRANSACTION as any);
+    const body = JSON.stringify({ event: 'payment_order.pending', data: { id: 'order-pending-1' } });
+    const sig = await hmacHex(body, 'test-webhook-secret');
+    await POST(makeRequest(body, sig));
+    expect(dal.update).toHaveBeenCalledWith('tx-1', { payoutStatus: 'pending' });
+  });
+
+  it('returns 200 without updating when no transaction found for orderId', async () => {
+    // getByPayoutOrderId already returns null from beforeEach
+    const body = JSON.stringify({ event: 'payment_order.settled', data: { id: 'order-unknown-1' } });
+    const sig = await hmacHex(body, 'test-webhook-secret');
+    const res = await POST(makeRequest(body, sig));
+    expect(res.status).toBe(200);
+    expect(dal.update).not.toHaveBeenCalled();
+  });
+
+  it('fires notification after status update', async () => {
+    vi.mocked(dal.getByPayoutOrderId).mockResolvedValue(FAKE_TRANSACTION as any);
+    const body = JSON.stringify({ event: 'payment_order.settled', data: { id: 'order-notify-1' } });
+    const sig = await hmacHex(body, 'test-webhook-secret');
+    await POST(makeRequest(body, sig));
+    expect(notifyTransactionStatusUpdate).toHaveBeenCalledOnce();
+  });
+
+  it('warns on unhandled event type', async () => {
+    vi.mocked(dal.getByPayoutOrderId).mockResolvedValue(FAKE_TRANSACTION as any);
+    const body = JSON.stringify({ event: 'payment_order.unknown', data: { id: 'order-unknown-event-1' } });
+    const sig = await hmacHex(body, 'test-webhook-secret');
+    await POST(makeRequest(body, sig));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unhandled event type'));
+  });
+
+  it('returns 400 for malformed JSON payload', async () => {
+    const body = 'not-json-payload-unique';
+    const sig = await hmacHex(body, 'test-webhook-secret');
+    const res = await POST(makeRequest(body, sig));
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
closes #319 
closes #320 
closes #321 
closes #322


- Quote endpoint: valid quotes, 400/502 error cases
- Bridge build-tx: XDR generation, validation, rate limit, SDK errors
- Execute-payout: transaction creation, feeMethod normalization, DB errors
- Paycrest order: order creation, field validation, HTTP error propagation
- Webhook handler: HMAC verification, all event types, notification firing

Mocks: Allbridge SDK, Paycrest API, DB (dal), rate limiters