### PR TITLE
feat(a11y): add global focus-visible styles for all interactive elements

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,6 +51,20 @@ html[data-theme="light"] body {
 
 button { font: inherit; color: inherit; background: none; border: 0; cursor: pointer; }
 
+/* Global focus styles for keyboard navigation accessibility (#396) */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+[role="button"]:focus-visible,
+[role="link"]:focus-visible,
+[tabindex]:not([tabindex="-1"]):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;


### PR DESCRIPTION
- Apply consistent focus ring to all interactive elements: a, button, input, textarea, select, [role=button], [role=link], [tabindex]
- Use accent color for focus ring with 2px offset
- Supports focus-visible (keyboard-only, no mouse focus ring)
- Ensures sufficient contrast for keyboard navigation

Closes #396