### PR TITLE
feat(a11y): add comprehensive text alternatives for non-text content

### DIFF
--- a/src/lib/aria-labels.ts
+++ b/src/lib/aria-labels.ts
@@ -1,12 +1,12 @@
 /**
- * ARIA utilities for accessibility
+ * ARIA utilities for accessibility (#397 - Text alternatives for non-text content)
  */
 
 export const ariaLabels = {
   // Navigation
   mainNav: "Main navigation",
   skipToContent: "Skip to main content",
-  
+
   // Forms
   amountInput: "Enter amount in USDC",
   currencySelect: "Select destination currency",
@@ -14,7 +14,7 @@ export const ariaLabels = {
   accountNumberInput: "Enter recipient account number",
   accountNameInput: "Enter recipient account name",
   feeMethodSelect: "Select fee payment method",
-  
+
   // Buttons
   connectWallet: "Connect your Stellar wallet",
   disconnectWallet: "Disconnect wallet",
@@ -22,26 +22,53 @@ export const ariaLabels = {
   confirmTransaction: "Confirm and proceed with transaction",
   cancelTransaction: "Cancel transaction",
   editTransaction: "Edit transaction details",
-  
+  copyToClipboard: "Copy to clipboard",
+  closeModal: "Close dialog",
+  toggleTheme: (current: string, next: string) => `Switch to ${next} mode. Current theme: ${current}`,
+
   // Status
   loadingIndicator: "Loading",
   successMessage: "Operation completed successfully",
   errorMessage: "An error occurred",
   warningMessage: "Warning",
-  
+
   // Modals
   previewModal: "Transaction preview",
   walletModal: "Wallet selection",
   shortcutsModal: "Keyboard shortcuts",
-  
+
   // Tables
   transactionTable: "Recent transactions",
   transactionRow: (txHash: string) => `Transaction ${txHash}`,
-  
+
   // Live regions
   quoteUpdate: "Exchange rate and quote updated",
   transactionStatus: "Transaction status updated",
   errorNotification: "Error notification",
+
+  // Charts and graphs (#397)
+  analyticsChart: "Analytics chart showing transaction data",
+  fxRateChart: "Exchange rate chart",
+  transactionVolumeChart: (currency: string, amount: string) =>
+    `Transaction volume chart: ${amount} in ${currency}`,
+  progressBar: (percent: number, label: string) => `${label}: ${percent}% complete`,
+  statusIndicator: (status: string) => `Status: ${status}`,
+
+  // Images (#397)
+  walletLogo: (walletName: string) => `${walletName} wallet logo`,
+  currencyFlag: (currency: string) => `${currency} currency flag`,
+  qrCode: (content: string) => `QR code for ${content}`,
+  architectureDiagram: "Stellar-Spend architecture diagram showing the transaction flow from user wallet through Allbridge bridge to Paycrest payout",
+
+  // Icons with meaning (#397)
+  successIcon: "Success",
+  errorIcon: "Error",
+  warningIcon: "Warning",
+  infoIcon: "Information",
+  externalLinkIcon: "Opens in new tab",
+  copyIcon: "Copy",
+  checkIcon: "Confirmed",
+  spinnerIcon: "Loading",
 };
 
 export const ariaDescriptions = {
@@ -49,6 +76,8 @@ export const ariaDescriptions = {
   payoutFee: "Fee charged by the payout provider for bank settlement",
   estimatedTime: "Approximate time for the transaction to complete",
   feeMethod: "Choose to pay fees in XLM (native) or USDC (stablecoin)",
+  highContrastMode: "High contrast mode increases color contrast for better visibility",
+  qrCodeScan: "Scan this QR code with your mobile device to share transaction details",
 };
 
 export const ariaLive = {


### PR DESCRIPTION
- Expand aria-labels with descriptions for charts and graphs
- Add alt text helpers for wallet logos, currency flags, QR codes
- Add architecture diagram description
- Add icon labels for success/error/warning/info states
- Add descriptions for high contrast mode and QR code scanning
- Provide ariaDescriptions for complex UI elements

Closes #397