### PR TITLE
feat(frontend): skeletons, optimistic UI, validation, filters (#438-441)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -209,6 +209,11 @@ select:focus-visible,
   50% { opacity: 0.65; }
 }
 
+@keyframes skeleton-shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
 .skeleton {
   background: var(--line);
   border-radius: 3px;
@@ -216,6 +221,28 @@ select:focus-visible,
   display: inline-block;
   pointer-events: none;
   user-select: none;
+  position: relative;
+  overflow: hidden;
+}
+
+/* Shimmer overlay layered on top of the base pulse. */
+.skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.06) 50%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.8s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton,
+  .skeleton::after { animation: none; }
 }
 
 @utility dot-bounce {

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -44,34 +44,17 @@ function getCurrencySymbol(currency: string): string {
   return symbols[currency.toUpperCase()] || currency.toUpperCase();
 }
 
-function StatusBadge({ status }: { status: Transaction["status"] }) {
-  const styles = {
-    pending: "bg-yellow-500/20 text-yellow-500 border-yellow-500/30",
-    completed: "bg-green-500/20 text-green-500 border-green-500/30",
-    failed: "bg-red-500/20 text-red-500 border-red-500/30",
-  };
-  return (
-    <span
-      className={cn(
-        "inline-block px-2.5 py-0.5 text-[10px] tracking-widest uppercase font-semibold border",
-        styles[status],
-      )}
-    >
-      {status}
-    </span>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Filter state
 // ---------------------------------------------------------------------------
 
-type SortField = "timestamp" | "amount";
+type SortField = "timestamp" | "amount" | "status";
 type SortDir = "asc" | "desc";
 
 interface Filters {
   search: string;
   status: Transaction["status"] | "all";
+  currency: string; // "" = all
   dateFrom: string;
   dateTo: string;
   amountMin: string;
@@ -83,6 +66,7 @@ interface Filters {
 const DEFAULT_FILTERS: Filters = {
   search: "",
   status: "all",
+  currency: "",
   dateFrom: "",
   dateTo: "",
   amountMin: "",
@@ -90,6 +74,33 @@ const DEFAULT_FILTERS: Filters = {
   sortField: "timestamp",
   sortDir: "desc",
 };
+
+const FILTERS_STORAGE_KEY = "stellar_spend_history_filters";
+
+function loadStoredFilters(): Filters {
+  if (typeof window === "undefined") return DEFAULT_FILTERS;
+  try {
+    const raw = localStorage.getItem(FILTERS_STORAGE_KEY);
+    if (!raw) return DEFAULT_FILTERS;
+    const parsed = JSON.parse(raw);
+    // Merge with defaults so older stored shapes don't drop new fields.
+    return { ...DEFAULT_FILTERS, ...parsed };
+  } catch {
+    return DEFAULT_FILTERS;
+  }
+}
+
+function activeFilterCount(filters: Filters): number {
+  let count = 0;
+  if (filters.search.trim()) count++;
+  if (filters.status !== "all") count++;
+  if (filters.currency) count++;
+  if (filters.dateFrom) count++;
+  if (filters.dateTo) count++;
+  if (filters.amountMin) count++;
+  if (filters.amountMax) count++;
+  return count;
+}
 
 // ---------------------------------------------------------------------------
 // Page
@@ -100,10 +111,28 @@ export default function HistoryPage() {
     useStellarWallet();
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS);
+  const [filtersLoaded, setFiltersLoaded] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [editingNoteId, setEditingNoteId] = useState<string | null>(null);
   const [noteInput, setNoteInput] = useState("");
+  const [noteError, setNoteError] = useState<string | null>(null);
+
+  // Hydrate filters from localStorage on mount (client-only).
+  useEffect(() => {
+    setFilters(loadStoredFilters());
+    setFiltersLoaded(true);
+  }, []);
+
+  // Persist filters whenever they change (after initial hydration).
+  useEffect(() => {
+    if (!filtersLoaded) return;
+    try {
+      localStorage.setItem(FILTERS_STORAGE_KEY, JSON.stringify(filters));
+    } catch {
+      // localStorage may be unavailable (e.g. quota, private mode); fail silently.
+    }
+  }, [filters, filtersLoaded]);
 
   useEffect(() => {
     if (!wallet?.publicKey) {
@@ -147,12 +176,39 @@ export default function HistoryPage() {
   const set = <K extends keyof Filters>(key: K, value: Filters[K]) =>
     setFilters((prev) => ({ ...prev, [key]: value }));
 
-  const saveNote = (id: string) => {
-    TransactionStorage.updateNote(id, noteInput);
-    setTransactions((prev) =>
-      prev.map((tx) => (tx.id === id ? { ...tx, note: noteInput.slice(0, 500) } : tx)),
-    );
+  // Optimistic note save: update UI + local storage immediately, persist to
+  // the server, and rollback both layers if the request fails.
+  const saveNote = async (id: string) => {
+    const trimmed = noteInput.slice(0, 500);
+    const previous = transactions.find((tx) => tx.id === id)?.note;
+
     setEditingNoteId(null);
+    setNoteError(null);
+
+    // Optimistic UI + local persistence.
+    setTransactions((prev) =>
+      prev.map((tx) => (tx.id === id ? { ...tx, note: trimmed } : tx)),
+    );
+    const rollbackLocal = TransactionStorage.applyOptimistic(id, { note: trimmed });
+
+    try {
+      const res = await fetch(`/api/transactions/${encodeURIComponent(id)}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ note: trimmed }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error ?? `Save failed (${res.status})`);
+      }
+    } catch (err) {
+      // Rollback UI + local storage.
+      setTransactions((prev) =>
+        prev.map((tx) => (tx.id === id ? { ...tx, note: previous } : tx)),
+      );
+      rollbackLocal();
+      setNoteError(err instanceof Error ? err.message : "Failed to save note");
+    }
   };
 
   const toggleSort = (field: SortField) =>
@@ -162,6 +218,13 @@ export default function HistoryPage() {
       sortDir:
         prev.sortField === field && prev.sortDir === "desc" ? "asc" : "desc",
     }));
+
+  // Distinct currencies present in the user's transactions, for the filter dropdown.
+  const availableCurrencies = useMemo(() => {
+    const set = new Set<string>();
+    transactions.forEach((tx) => tx.currency && set.add(tx.currency));
+    return Array.from(set).sort();
+  }, [transactions]);
 
   const filtered = useMemo(() => {
     let result = [...transactions];
@@ -182,13 +245,17 @@ export default function HistoryPage() {
       result = result.filter((tx) => tx.status === filters.status);
     }
 
+    // Currency filter
+    if (filters.currency) {
+      result = result.filter((tx) => tx.currency === filters.currency);
+    }
+
     // Date range
     if (filters.dateFrom) {
       const from = new Date(filters.dateFrom).getTime();
       result = result.filter((tx) => tx.timestamp >= from);
     }
     if (filters.dateTo) {
-      // include the full end day
       const to = new Date(filters.dateTo).getTime() + 86_400_000 - 1;
       result = result.filter((tx) => tx.timestamp <= to);
     }
@@ -209,20 +276,18 @@ export default function HistoryPage() {
     result.sort((a, b) => {
       let diff = 0;
       if (filters.sortField === "timestamp") diff = a.timestamp - b.timestamp;
-      else diff = parseFloat(a.amount) - parseFloat(b.amount);
+      else if (filters.sortField === "amount")
+        diff = parseFloat(a.amount) - parseFloat(b.amount);
+      else if (filters.sortField === "status")
+        diff = a.status.localeCompare(b.status);
       return filters.sortDir === "asc" ? diff : -diff;
     });
 
     return result;
   }, [transactions, filters]);
 
-  const hasActiveFilters =
-    filters.search ||
-    filters.status !== "all" ||
-    filters.dateFrom ||
-    filters.dateTo ||
-    filters.amountMin ||
-    filters.amountMax;
+  const filterCount = activeFilterCount(filters);
+  const hasActiveFilters = filterCount > 0;
 
   const SortIcon = ({ field }: { field: SortField }) => {
     if (filters.sortField !== field)
@@ -303,6 +368,19 @@ export default function HistoryPage() {
 
             {/* ── Filters ── */}
             <div className="border border-[#333333] bg-[#111111] p-4 mt-4">
+              <div className="mb-3 flex items-center gap-2">
+                <h2 className="text-[10px] tracking-widest uppercase text-[#aaaaaa]">
+                  Filters
+                </h2>
+                {hasActiveFilters && (
+                  <span
+                    aria-label={`${filterCount} active filter${filterCount === 1 ? "" : "s"}`}
+                    className="inline-flex items-center justify-center min-w-[20px] h-[20px] px-1.5 text-[10px] font-bold rounded-full bg-[#c9a962] text-[#0a0a0a]"
+                  >
+                    {filterCount}
+                  </span>
+                )}
+              </div>
               <div className="flex flex-wrap gap-3 items-end">
                 {/* Search */}
                 <div className="flex flex-col gap-1">
@@ -344,6 +422,34 @@ export default function HistoryPage() {
                     <option value="pending">Pending</option>
                     <option value="completed">Completed</option>
                     <option value="failed">Failed</option>
+                    <option value="reversed">Reversed</option>
+                    <option value="partially_reversed">Partially reversed</option>
+                  </select>
+                </div>
+
+                {/* Currency */}
+                <div className="flex flex-col gap-1">
+                  <label className="text-[10px] text-[#777777] uppercase tracking-widest">
+                    Currency
+                  </label>
+                  <select
+                    value={filters.currency}
+                    onChange={(e) => set("currency", e.target.value)}
+                    aria-label="Filter by currency"
+                    disabled={availableCurrencies.length === 0}
+                    className={cn(
+                      "bg-[#0a0a0a] border border-[#333333] px-3 py-2",
+                      "text-xs text-white",
+                      "focus:outline-none focus:border-[#c9a962]",
+                      "disabled:opacity-50 disabled:cursor-not-allowed",
+                    )}
+                  >
+                    <option value="">All</option>
+                    {availableCurrencies.map((c) => (
+                      <option key={c} value={c}>
+                        {getCurrencyFlag(c) ? `${getCurrencyFlag(c)} ${c}` : c}
+                      </option>
+                    ))}
                   </select>
                 </div>
 
@@ -421,7 +527,6 @@ export default function HistoryPage() {
                   />
                 </div>
 
-                {/* Reset */}
                 {hasActiveFilters && (
                   <button
                     onClick={() => setFilters(DEFAULT_FILTERS)}
@@ -431,11 +536,17 @@ export default function HistoryPage() {
                       "hover:border-[#c9a962] hover:text-[#c9a962] transition-colors duration-150",
                     )}
                   >
-                    Reset filters
+                    Clear filters
                   </button>
                 )}
               </div>
             </div>
+
+            {noteError && (
+              <div role="alert" className="mt-3 border border-red-500/30 bg-red-500/10 px-4 py-2 text-xs text-red-400">
+                {noteError}
+              </div>
+            )}
 
             {/* ── Table ── */}
             {filtered.length === 0 ? (
@@ -454,7 +565,6 @@ export default function HistoryPage() {
                 >
                   <thead>
                     <tr className="bg-[#c9a962]">
-                      {/* Sortable: DATE */}
                       <th
                         className="px-5 py-2.5 text-left text-[10px] tracking-[0.18em] font-semibold text-[#0a0a0a] uppercase whitespace-nowrap cursor-pointer select-none"
                         onClick={() => toggleSort("timestamp")}
@@ -471,7 +581,6 @@ export default function HistoryPage() {
                       <th className="px-5 py-2.5 text-left text-[10px] tracking-[0.18em] font-semibold text-[#0a0a0a] uppercase whitespace-nowrap">
                         TX HASH
                       </th>
-                      {/* Sortable: AMOUNT */}
                       <th
                         className="px-5 py-2.5 text-left text-[10px] tracking-[0.18em] font-semibold text-[#0a0a0a] uppercase whitespace-nowrap cursor-pointer select-none"
                         onClick={() => toggleSort("amount")}
@@ -491,8 +600,18 @@ export default function HistoryPage() {
                       <th className="px-5 py-2.5 text-left text-[10px] tracking-[0.18em] font-semibold text-[#0a0a0a] uppercase whitespace-nowrap">
                         BANK
                       </th>
-                      <th className="px-5 py-2.5 text-left text-[10px] tracking-[0.18em] font-semibold text-[#0a0a0a] uppercase whitespace-nowrap">
-                        STATUS
+                      <th
+                        className="px-5 py-2.5 text-left text-[10px] tracking-[0.18em] font-semibold text-[#0a0a0a] uppercase whitespace-nowrap cursor-pointer select-none"
+                        onClick={() => toggleSort("status")}
+                        aria-sort={
+                          filters.sortField === "status"
+                            ? filters.sortDir === "asc"
+                              ? "ascending"
+                              : "descending"
+                            : "none"
+                        }
+                      >
+                        STATUS <SortIcon field="status" />
                       </th>
                       <th className="px-5 py-2.5 text-left text-[10px] tracking-[0.18em] font-semibold text-[#0a0a0a] uppercase whitespace-nowrap">
                         NOTE

--- a/src/components/AnalyticsDashboard.tsx
+++ b/src/components/AnalyticsDashboard.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { AnalyticsPeriod } from '@/types/analytics';
 import { FunnelChart } from '@/components/FunnelChart';
+import { AnalyticsDashboardSkeleton } from '@/components/skeletons';
 
 interface AnalyticsDashboardProps {
   userAddress: string;
@@ -44,7 +45,7 @@ export function AnalyticsDashboard({ userAddress }: AnalyticsDashboardProps) {
     }
   };
 
-  if (loading) return <div className="text-center py-8">Loading analytics...</div>;
+  if (loading) return <AnalyticsDashboardSkeleton />;
   if (error) return <div className="text-red-600 py-8">{error}</div>;
   if (!analytics) return <div className="text-center py-8">No data available</div>;
 

--- a/src/components/FavoriteButton.tsx
+++ b/src/components/FavoriteButton.tsx
@@ -14,43 +14,62 @@ export function FavoriteButton({
   isFavorite = false,
   onToggle,
 }: FavoriteButtonProps) {
-  const [isLoading, setIsLoading] = useState(false);
   const [favorite, setFavorite] = useState(isFavorite);
+  const [error, setError] = useState<string | null>(null);
 
   const handleToggle = async () => {
-    setIsLoading(true);
+    // Optimistic flip — show the new state immediately.
+    const previous = favorite;
+    const next = !previous;
+    setFavorite(next);
+    setError(null);
+    onToggle?.(next);
+
     try {
       const res = await fetch('/api/transactions/favorites', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ transactionId }),
+        body: JSON.stringify({ transactionId, isFavorite: next }),
       });
-
-      if (res.ok) {
-        const data = await res.json();
+      if (!res.ok) throw new Error('Request failed');
+      const data = await res.json();
+      // Reconcile with server truth in case it differs.
+      if (typeof data.isFavorite === 'boolean' && data.isFavorite !== next) {
         setFavorite(data.isFavorite);
         onToggle?.(data.isFavorite);
       }
-    } catch (error) {
-      console.error('Failed to toggle favorite:', error);
-    } finally {
-      setIsLoading(false);
+    } catch (err) {
+      // Rollback on failure.
+      setFavorite(previous);
+      onToggle?.(previous);
+      setError(err instanceof Error ? err.message : 'Failed to update favorite');
     }
   };
 
   return (
-    <button
-      onClick={handleToggle}
-      disabled={isLoading}
-      className={cn(
-        'p-1 transition-colors',
-        favorite
-          ? 'text-yellow-500 hover:text-yellow-600'
-          : 'text-[#666666] hover:text-[#999999]'
+    <span className="inline-flex flex-col items-start">
+      <button
+        type="button"
+        onClick={handleToggle}
+        className={cn(
+          'p-1 transition-colors',
+          favorite
+            ? 'text-yellow-500 hover:text-yellow-600'
+            : 'text-[#666666] hover:text-[#999999]'
+        )}
+        title={favorite ? 'Remove from favorites' : 'Add to favorites'}
+        aria-pressed={favorite}
+        aria-label={favorite ? 'Remove from favorites' : 'Add to favorites'}
+      >
+        <span className="text-lg" aria-hidden="true">
+          {favorite ? '★' : '☆'}
+        </span>
+      </button>
+      {error && (
+        <span role="alert" className="text-[10px] text-red-400 mt-0.5">
+          {error}
+        </span>
       )}
-      title={favorite ? 'Remove from favorites' : 'Add to favorites'}
-    >
-      <span className="text-lg">{favorite ? '★' : '☆'}</span>
-    </button>
+    </span>
   );
 }

--- a/src/components/FormCard.tsx
+++ b/src/components/FormCard.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { ChangeEvent } from "react";
+import { ChangeEvent, useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/cn";
-import { validateAmount, validateAccountNumber, isValidQuote, validateEvmAddress } from "@/lib/offramp/utils/validation";
-import { buildQuote, calculateBridgeAmount } from "@/lib/offramp/utils/quote-fetcher";
+import {
+  validateAmount,
+  validateAccountNumber,
+  isValidQuote,
+} from "@/lib/offramp/utils/validation";
 import { getCurrencyFlag } from "@/lib/currency-flags";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { FormCardSkeleton } from "@/components/skeletons";
@@ -11,373 +14,82 @@ import { BankAccountInput, type BankMode } from "@/components/BankAccountInput";
 import { QuoteComparison, type ProviderQuote } from "@/components/QuoteComparison";
 import { Tooltip } from "@/components/Tooltip";
 import { useFxRate } from "@/hooks/useFxRate";
+import type { QuoteResult as QuoteFetcherResult } from "@/lib/offramp/utils/quote-fetcher";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-export interface FeeOption {
-  label: string;
+export type FeeMethod = "USDC" | "XLM";
+
+export type QuoteResult = QuoteFetcherResult;
+
+export interface Currency {
+  code: string;
+  name: string;
+}
+
+export interface Institution {
+  code: string;
+  name: string;
+}
+
+export interface GasFeeOptions {
+  usdcFee: string;
+  xlmFee: string;
+}
+
+export interface OfframpPayload {
   amount: string;
-  method: "native" | "stablecoin";
+  currency: string;
+  institution: string;
+  /** Account number, ABA routing number, or IBAN depending on bankMode */
+  accountIdentifier: string;
+  accountName: string;
+  feeMethod: FeeMethod;
+  bankMode: BankMode;
+  routingNumber?: string;
+  iban?: string;
+  quote: QuoteResult | null;
 }
 
 export interface FormCardProps {
-  // Controlled field values
-  amount: string;
-  currency: string;
-  bank: string;
-  accountNumber: string;
-  accountName: string;
-  feeMethod: "native" | "stablecoin";
-  // Options
-  currencies: Array<{ value: string; label: string }>;
-  banks: Array<{ value: string; label: string }>;
-  feeOptions: FeeOption[];
-  // Loading states
-  isLoadingCurrencies?: boolean;
-  isLoadingBanks?: boolean;
-  isLoadingQuote?: boolean;
-  isLoadingFees?: boolean;
-  isVerifyingAccount?: boolean;
-  /** Show a full-form skeleton (e.g. on first mount before wallet is ready) */
-  isInitialLoading?: boolean;
-  // Quote display
-  quoteSuffix?: string;
-  // Wallet state
   isConnected: boolean;
   isConnecting: boolean;
-  // Callbacks
-  onAmountChange: (v: string) => void;
-  onCurrencyChange: (v: string) => void;
-  onBankChange: (v: string) => void;
-  onAccountNumberChange: (v: string) => void;
-  onFeeMethodChange: (v: "native" | "stablecoin") => void;
-  onSubmit: () => void;
+  onConnect: () => void;
+  onSubmit: (payload: OfframpPayload) => void;
+  resetKey?: number;
+  onQuoteChange?: (quote: QuoteResult | null) => void;
+  onAmountChange?: (v: string) => void;
+  onCurrencyChange?: (v: string) => void;
+  /** Show a full-form skeleton (e.g. on first mount before wallet is ready) */
+  isInitialLoading?: boolean;
 }
 
 // ---------------------------------------------------------------------------
-// Sub-components
+// Helpers
 // ---------------------------------------------------------------------------
 
-interface InputFieldProps {
-  label: string;
-  id: string;
-  value: string;
-  onChange: (v: string) => void;
-  onBlur?: () => void;
-  type?: string;
-  placeholder?: string;
-  min?: string;
-  step?: string;
-  maxLength?: number;
-  disabled?: boolean;
-  suffix?: string;
-  error?: string;
-  success?: string;
-  touched?: boolean;
-  inputMode?: "numeric" | "decimal" | "text";
-  help?: string;
-}
-
-function InputField({
-  label,
-  id,
-  value,
-  onChange,
-  onBlur,
-  type = "text",
-  placeholder,
-  min,
-  step,
-  maxLength,
-  disabled,
-  suffix,
-  error,
-  success,
-  touched,
-  inputMode,
-  help,
-}: InputFieldProps) {
-  const showError = touched && error;
-  const showSuccess = touched && !error && success && value;
-
-  return (
-    <div className="flex flex-col gap-1.5">
-      <div className="flex items-center gap-2">
-        <label htmlFor={id} className="text-[10px] tracking-[0.18em] text-[#777777] uppercase">
-          {label}
-        </label>
-        {help && (
-          <Tooltip content={help} position="top">
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              className="text-[#777777] hover:text-[#c9a962] cursor-help transition-colors"
-            >
-              <circle cx="12" cy="12" r="10"></circle>
-              <path d="M12 16v-4"></path>
-              <path d="M12 8h.01"></path>
-            </svg>
-          </Tooltip>
-        )}
-      </div>
-      <div className="relative flex items-center">
-        <input
-          id={id}
-          type={type}
-          value={value}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
-          onBlur={onBlur}
-          placeholder={placeholder}
-          min={min}
-          step={step}
-          maxLength={maxLength}
-          disabled={disabled}
-          inputMode={inputMode}
-          aria-invalid={showError ? "true" : undefined}
-          aria-describedby={showError ? `${id}-error` : showSuccess ? `${id}-success` : undefined}
-          className={cn(
-            "w-full bg-[#0a0a0a] border px-3 py-2.5 text-sm text-white placeholder-[#444444]",
-            "focus:outline-none focus-visible:ring-1 focus-visible:ring-[#c9a962]",
-            "disabled:opacity-40 disabled:cursor-not-allowed",
-            "transition-colors duration-150",
-            showError
-              ? "border-red-500/60 focus:border-red-500/80"
-              : showSuccess
-              ? "border-green-500/50 focus:border-green-500/70"
-              : "border-[#333333] focus:border-[#c9a962]",
-            suffix && "pr-20"
-          )}
-        />
-        {/* Validation state icon */}
-        {!disabled && value && (
-          <span className="absolute right-3 pointer-events-none select-none flex items-center">
-            {suffix && !showError && !showSuccess && (
-              <span className="text-xs text-[#777777]">{suffix}</span>
-            )}
-            {showError && (
-              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" className="text-red-400" aria-hidden="true">
-                <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5" />
-                <path d="M8 4.5V8.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-                <circle cx="8" cy="11" r="0.75" fill="currentColor" />
-              </svg>
-            )}
-            {showSuccess && (
-              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" className="text-green-400" aria-hidden="true">
-                <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5" />
-                <path d="M5 8L7 10L11 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
-            )}
-            {!showError && !showSuccess && suffix && value && (
-              <span className="sr-only">{suffix}</span>
-            )}
-          </span>
-        )}
-        {/* Suffix when no value or no validation state */}
-        {suffix && !value && (
-          <span className="absolute right-3 text-xs text-[#777777] pointer-events-none select-none">
-            {suffix}
-          </span>
-        )}
-      </div>
-      {showError && (
-        <span id={`${id}-error`} role="alert" className="flex items-center gap-1 text-[10px] text-red-400 tracking-wide">
-          {error}
-        </span>
-      )}
-      {showSuccess && (
-        <span id={`${id}-success`} className="text-[10px] text-green-400 tracking-wide">
-          {success}
-        </span>
-      )}
-    </div>
-  );
-}
-
-interface SelectFieldProps {
-  label: string;
-  id: string;
-  value: string;
-  onChange: (v: string) => void;
-  onBlur?: () => void;
-  options: Array<{ value: string; label: string }>;
-  placeholder?: string;
-  disabled?: boolean;
-  loading?: boolean;
-  error?: string;
-  touched?: boolean;
-}
-
-function SelectField({
-  label,
-  id,
-  value,
-  onChange,
-  onBlur,
-  options,
-  placeholder = "Select...",
-  disabled,
-  loading,
-  error,
-  touched,
-}: SelectFieldProps) {
-  const showError = touched && error && !value;
-
-  return (
-    <div className="flex flex-col gap-1.5">
-      <label htmlFor={id} className="text-[10px] tracking-[0.18em] text-[#777777] uppercase">
-        {label}
-      </label>
-      <div className="relative">
-        <select
-          id={id}
-          value={value}
-          onChange={(e: ChangeEvent<HTMLSelectElement>) => onChange(e.target.value)}
-          onBlur={onBlur}
-          disabled={disabled || loading}
-          aria-invalid={showError ? "true" : undefined}
-          aria-describedby={showError ? `${id}-error` : undefined}
-          className={cn(
-            "w-full appearance-none bg-[#0a0a0a] border px-3 py-2.5 text-sm",
-            "focus:outline-none focus-visible:ring-1 focus-visible:ring-[#c9a962] focus:border-[#c9a962]",
-            "disabled:opacity-40 disabled:cursor-not-allowed",
-            "transition-colors duration-150",
-            showError ? "border-red-500/60" : value ? "border-[#c9a962]/40" : "border-[#333333]",
-            value ? "text-white" : "text-[#444444]"
-          )}
-        >
-          <option value="" disabled>
-            {loading ? "Loading..." : placeholder}
-          </option>
-          {options.map((opt) => (
-            <option key={opt.value} value={opt.value} className="bg-[#111111] text-white">
-              {opt.label}
-            </option>
-          ))}
-        </select>
-        {/* Chevron */}
-        <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[#777777] text-xs">
-          ▾
-        </span>
-      </div>
-      {showError && (
-        <span id={`${id}-error`} role="alert" className="text-[10px] text-red-400 tracking-wide">
-          {error}
-        </span>
-      )}
-    </div>
-  );
-}
-
-interface FieldProps {
-  label: string;
-  value: string;
-  loading?: boolean;
-  placeholder?: string;
-  success?: boolean;
-}
-
-function Field({ label, value, loading, placeholder = "—", success }: FieldProps) {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <span className="text-[10px] tracking-[0.18em] text-[#777777] uppercase">{label}</span>
-      <div className={cn(
-        "bg-[#0a0a0a] border px-3 py-2.5 text-sm min-h-[42px] flex items-center justify-between",
-        success && value ? "border-green-500/40" : "border-[#333333]"
-      )}>
-        <span>
-          {loading ? (
-            <span className="text-[#777777] text-xs tracking-wider">Resolving...</span>
-          ) : value ? (
-            <span className="text-[#c9a962]">{value}</span>
-          ) : (
-            <span className="text-[#444444]">{placeholder}</span>
-          )}
-        </span>
-        {success && value && !loading && (
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" className="text-green-400 shrink-0" aria-hidden="true">
-            <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5" />
-            <path d="M5 8L7 10L11 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-        )}
-      </div>
-    </div>
-  );
-}
-
-interface FeeMethodSelectorProps {
-  value: FeeMethod;
-  onChange: (v: FeeMethod) => void;
-  usdcFee: string | null;
-  xlmFee: string | null;
-  disabled?: boolean;
-}
-
-function FeeMethodSelector({ value, onChange, usdcFee, xlmFee, disabled }: FeeMethodSelectorProps) {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <span className="text-[10px] tracking-[0.18em] text-[#777777] uppercase">Gas Fee Method</span>
-      <div className="flex gap-2">
-        {(["USDC", "XLM"] as FeeMethod[]).map((method) => {
-          const fee = method === "USDC" ? usdcFee : xlmFee;
-          const active = value === method;
-          return (
-            <button
-              key={method}
-              type="button"
-              onClick={() => onChange(method)}
-              disabled={disabled}
-              className={cn(
-                "flex-1 py-2.5 px-3 min-h-[44px] text-xs tracking-widest border transition-colors duration-150",
-                "focus:outline-none focus-visible:ring-1 focus-visible:ring-[#c9a962]",
-                "disabled:opacity-40 disabled:cursor-not-allowed",
-                active
-                  ? "border-[#c9a962] bg-[#c9a962]/10 text-[#c9a962]"
-                  : "border-[#333333] bg-[#0a0a0a] text-[#777777] hover:border-[#c9a962]/50"
-              )}
-            >
-              <span className="block font-semibold">{method}</span>
-              {fee && (
-                <span className="block text-[10px] mt-0.5 opacity-80">{fee}</span>
-              )}
-            </button>
-          );
-        })}
-      </div>
-      <p className="text-[10px] text-[#777777] leading-relaxed">
-        {value === "XLM"
-          ? "XLM will be used to cover Stellar network fees."
-          : "A small USDC amount will be deducted to cover network fees."}
-      </p>
-    </div>
-  );
-}
+const CURRENCY_SYMBOLS: Record<string, string> = {
+  NGN: "₦",
+  USD: "$",
+  EUR: "€",
+  GBP: "£",
+  KES: "KSh",
+  GHS: "₵",
+  ZAR: "R",
+};
 
 function getCurrencySymbol(currency: string): string {
-  const symbols: Record<string, string> = {
-    NGN: "₦",
-    USD: "$",
-    EUR: "€",
-    GBP: "£",
-    KES: "KSh",
-    GHS: "₵",
-    ZAR: "R",
-  };
-  return symbols[currency.toUpperCase()] || currency.toUpperCase();
+  return CURRENCY_SYMBOLS[currency.toUpperCase()] || currency.toUpperCase();
 }
 
 function formatPayout(amount: string, currency: string): string {
   const num = parseFloat(amount);
   if (isNaN(num)) return "—";
   const symbol = getCurrencySymbol(currency);
-  
   if (currency.toUpperCase() === "NGN") {
-    return `${symbol}${new Intl.NumberFormat("en-NG", { minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(num)}`;
+    return `${symbol}${new Intl.NumberFormat("en-NG", { maximumFractionDigits: 0 }).format(num)}`;
   }
   try {
     return new Intl.NumberFormat("en-US", {
@@ -391,44 +103,6 @@ function formatPayout(amount: string, currency: string): string {
   }
 }
 
-interface PayoutBoxProps {
-  quote: QuoteResult;
-  currency: string;
-  liveRate?: number | null;
-  flash?: boolean;
-}
-
-function PayoutBox({ quote, currency, liveRate, flash }: PayoutBoxProps) {
-  const effectiveRate = liveRate ?? quote.rate;
-  const amount = parseFloat(quote.destinationAmount);
-  // Recalculate payout using live rate if available
-  const liveDestination =
-    liveRate && quote.rate > 0
-      ? ((amount / quote.rate) * liveRate).toFixed(2)
-      : quote.destinationAmount;
-
-  return (
-    <div className="border border-[#c9a962]/30 bg-[#c9a962]/5 px-4 py-3 flex items-center justify-between gap-4">
-      <div className="flex flex-col gap-0.5">
-        <span className="text-[10px] tracking-[0.18em] text-[#777777] uppercase">Estimated Payout</span>
-        <span className="text-[10px] text-[#777777]">
-          Rate: {currency.toUpperCase() === "NGN"
-            ? `${getCurrencySymbol(currency)}${new Intl.NumberFormat("en-NG").format(effectiveRate)}`
-            : `${getCurrencySymbol(currency)} ${effectiveRate.toFixed(4)}`} / USDC
-        </span>
-      </div>
-      <span
-        className={cn(
-          "font-space-grotesk font-bold text-lg tabular-nums transition-colors duration-300",
-          flash ? "text-white" : "text-[#c9a962]"
-        )}
-      >
-        {formatPayout(liveDestination, currency)}
-      </span>
-    </div>
-  );
-}
-
 function buildProviderQuotes(quote: QuoteResult, currency: string): ProviderQuote[] {
   const base = parseFloat(quote.destinationAmount);
   const baseRate = quote.rate;
@@ -439,7 +113,7 @@ function buildProviderQuotes(quote: QuoteResult, currency: string): ProviderQuot
       id: "paycrest",
       provider: "Paycrest",
       rate: baseRate,
-      bridgeFee: (baseFee).toFixed(2),
+      bridgeFee: baseFee.toFixed(2),
       payoutFee: "0.00",
       totalFee: baseFee.toFixed(2),
       estimatedTime: 300,
@@ -477,47 +151,337 @@ function buildProviderQuotes(quote: QuoteResult, currency: string): ProviderQuot
   ];
 }
 
-type CtaState = "disconnected" | "connecting" | "ready" | "submitting" | "invalid";
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface InputFieldProps {
+  label: string;
+  id: string;
+  value: string;
+  onChange: (v: string) => void;
+  onBlur?: () => void;
+  type?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  suffix?: string;
+  error?: string;
+  success?: string;
+  touched?: boolean;
+  inputMode?: "numeric" | "decimal" | "text";
+  help?: string;
+  validating?: boolean;
+}
+
+function InputField({
+  label,
+  id,
+  value,
+  onChange,
+  onBlur,
+  type = "text",
+  placeholder,
+  disabled,
+  suffix,
+  error,
+  success,
+  touched,
+  inputMode,
+  help,
+  validating,
+}: InputFieldProps) {
+  const showError = touched && !!error;
+  const showSuccess = touched && !error && !!success && !!value && !validating;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <label
+          htmlFor={id}
+          className="text-[10px] tracking-[0.18em] text-[#777777] uppercase"
+        >
+          {label}
+        </label>
+        {help && (
+          <Tooltip content={help} position="top">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              className="text-[#777777] hover:text-[#c9a962] cursor-help transition-colors"
+              aria-label="Help"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <path d="M12 16v-4" />
+              <path d="M12 8h.01" />
+            </svg>
+          </Tooltip>
+        )}
+      </div>
+      <div className="relative flex items-center">
+        <input
+          id={id}
+          type={type}
+          value={value}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+          onBlur={onBlur}
+          placeholder={placeholder}
+          disabled={disabled}
+          inputMode={inputMode}
+          aria-invalid={showError ? "true" : undefined}
+          aria-describedby={
+            showError ? `${id}-error` : showSuccess ? `${id}-success` : help ? `${id}-help` : undefined
+          }
+          className={cn(
+            "w-full bg-[#0a0a0a] border px-3 py-2.5 text-sm text-white placeholder-[#444444]",
+            "focus:outline-none focus-visible:ring-1 focus-visible:ring-[#c9a962]",
+            "disabled:opacity-40 disabled:cursor-not-allowed",
+            "transition-colors duration-150",
+            showError
+              ? "border-red-500/60 focus:border-red-500/80"
+              : showSuccess
+              ? "border-green-500/50 focus:border-green-500/70"
+              : "border-[#333333] focus:border-[#c9a962]",
+            suffix && "pr-20",
+          )}
+        />
+        <span className="absolute right-3 pointer-events-none select-none flex items-center gap-2">
+          {validating && (
+            <span
+              className="inline-block h-3 w-3 border-2 border-[#c9a962] border-t-transparent rounded-full animate-spin"
+              aria-label="Validating…"
+            />
+          )}
+          {!validating && showError && (
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" className="text-red-400" aria-hidden="true">
+              <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5" />
+              <path d="M8 4.5V8.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+              <circle cx="8" cy="11" r="0.75" fill="currentColor" />
+            </svg>
+          )}
+          {!validating && showSuccess && (
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" className="text-green-400" aria-hidden="true">
+              <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5" />
+              <path
+                d="M5 8L7 10L11 6"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          )}
+          {suffix && !showError && !showSuccess && !validating && (
+            <span className="text-xs text-[#777777]">{suffix}</span>
+          )}
+        </span>
+      </div>
+      {showError && (
+        <span id={`${id}-error`} role="alert" className="text-[10px] text-red-400 tracking-wide">
+          {error}
+        </span>
+      )}
+      {showSuccess && (
+        <span id={`${id}-success`} className="text-[10px] text-green-400 tracking-wide">
+          {success}
+        </span>
+      )}
+      {!showError && !showSuccess && help && (
+        <span id={`${id}-help`} className="text-[10px] text-[#666666] tracking-wide">
+          {help}
+        </span>
+      )}
+    </div>
+  );
+}
+
+interface SelectFieldProps {
+  label: string;
+  id: string;
+  value: string;
+  onChange: (v: string) => void;
+  onBlur?: () => void;
+  options: Array<{ value: string; label: string }>;
+  placeholder?: string;
+  disabled?: boolean;
+  loading?: boolean;
+  error?: string;
+  touched?: boolean;
+}
+
+function SelectField({
+  label,
+  id,
+  value,
+  onChange,
+  onBlur,
+  options,
+  placeholder = "Select...",
+  disabled,
+  loading,
+  error,
+  touched,
+}: SelectFieldProps) {
+  const showError = touched && !!error && !value;
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label htmlFor={id} className="text-[10px] tracking-[0.18em] text-[#777777] uppercase">
+        {label}
+      </label>
+      <div className="relative">
+        <select
+          id={id}
+          value={value}
+          onChange={(e: ChangeEvent<HTMLSelectElement>) => onChange(e.target.value)}
+          onBlur={onBlur}
+          disabled={disabled || loading}
+          aria-invalid={showError ? "true" : undefined}
+          aria-describedby={showError ? `${id}-error` : undefined}
+          className={cn(
+            "w-full appearance-none bg-[#0a0a0a] border px-3 py-2.5 text-sm",
+            "focus:outline-none focus-visible:ring-1 focus-visible:ring-[#c9a962] focus:border-[#c9a962]",
+            "disabled:opacity-40 disabled:cursor-not-allowed",
+            "transition-colors duration-150",
+            showError ? "border-red-500/60" : value ? "border-[#c9a962]/40" : "border-[#333333]",
+            value ? "text-white" : "text-[#444444]",
+          )}
+        >
+          <option value="" disabled>
+            {loading ? "Loading..." : placeholder}
+          </option>
+          {options.map((opt) => (
+            <option key={opt.value} value={opt.value} className="bg-[#111111] text-white">
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[#777777] text-xs">
+          ▾
+        </span>
+      </div>
+      {showError && (
+        <span id={`${id}-error`} role="alert" className="text-[10px] text-red-400 tracking-wide">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function ResolvedField({
+  label,
+  value,
+  loading,
+  placeholder = "—",
+}: {
+  label: string;
+  value: string;
+  loading?: boolean;
+  placeholder?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-[10px] tracking-[0.18em] text-[#777777] uppercase">{label}</span>
+      <div
+        className={cn(
+          "bg-[#0a0a0a] border px-3 py-2.5 text-sm min-h-[42px] flex items-center justify-between",
+          value && !loading ? "border-green-500/40" : "border-[#333333]",
+        )}
+      >
+        <span>
+          {loading ? (
+            <span className="text-[#777777] text-xs tracking-wider">Resolving...</span>
+          ) : value ? (
+            <span className="text-[#c9a962]">{value}</span>
+          ) : (
+            <span className="text-[#444444]">{placeholder}</span>
+          )}
+        </span>
+        {value && !loading && (
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" className="text-green-400 shrink-0" aria-hidden="true">
+            <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M5 8L7 10L11 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PayoutBox({
+  quote,
+  currency,
+  liveRate,
+  flash,
+}: {
+  quote: QuoteResult;
+  currency: string;
+  liveRate?: number | null;
+  flash?: boolean;
+}) {
+  const effectiveRate = liveRate ?? quote.rate;
+  const amount = parseFloat(quote.destinationAmount);
+  const liveDestination =
+    liveRate && quote.rate > 0
+      ? ((amount / quote.rate) * liveRate).toFixed(2)
+      : quote.destinationAmount;
+
+  return (
+    <div className="border border-[#c9a962]/30 bg-[#c9a962]/5 px-4 py-3 flex items-center justify-between gap-4">
+      <div className="flex flex-col gap-0.5">
+        <span className="text-[10px] tracking-[0.18em] text-[#777777] uppercase">Estimated Payout</span>
+        <span className="text-[10px] text-[#777777]">
+          Rate:{" "}
+          {currency.toUpperCase() === "NGN"
+            ? `${getCurrencySymbol(currency)}${new Intl.NumberFormat("en-NG").format(effectiveRate)}`
+            : `${getCurrencySymbol(currency)} ${effectiveRate.toFixed(4)}`}{" "}
+          / USDC
+        </span>
+      </div>
+      <span
+        className={cn(
+          "font-bold text-lg tabular-nums transition-colors duration-300",
+          flash ? "text-white" : "text-[#c9a962]",
+        )}
+      >
+        {formatPayout(liveDestination, currency)}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+type CtaState = "disconnected" | "connecting" | "ready" | "submitting";
 
 function getCtaLabel(state: CtaState): string {
   switch (state) {
-    case "disconnected": return "CONNECT WALLET";
-    case "connecting":   return "WAITING FOR SIGNATURE...";
-    case "submitting":   return "INITIATING OFFRAMP...";
-    case "invalid":      return "INITIATE OFFRAMP →";
-    case "ready":        return "INITIATE OFFRAMP →";
+    case "disconnected":
+      return "CONNECT WALLET";
+    case "connecting":
+      return "WAITING FOR SIGNATURE...";
+    case "submitting":
+      return "INITIATING OFFRAMP...";
+    default:
+      return "INITIATE OFFRAMP →";
   }
 }
 
-function getCtaDisabled(state: CtaState): boolean {
-  return state === "connecting" || state === "submitting" || state === "invalid";
-}
-
 export function FormCard({
-  amount,
-  currency,
-  bank,
-  accountNumber,
-  accountName,
-  feeMethod,
-  currencies,
-  banks,
-  feeOptions,
-  isLoadingCurrencies,
-  isLoadingBanks,
-  isLoadingQuote,
-  isLoadingFees,
-  isVerifyingAccount,
-  isInitialLoading,
-  quoteSuffix,
   isConnected,
   isConnecting,
+  onConnect,
+  onSubmit,
+  resetKey = 0,
+  onQuoteChange,
   onAmountChange,
   onCurrencyChange,
-  onBankChange,
-  onAccountNumberChange,
-  onFeeMethodChange,
-  onSubmit,
+  isInitialLoading,
 }: FormCardProps) {
   const [amount, setAmount] = useState("");
   const [feeMethod, setFeeMethod] = useState<FeeMethod>("USDC");
@@ -544,39 +508,37 @@ export function FormCard({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const [amountError, setAmountError] = useState("");
-  const [accountError, setAccountError] = useState("");
   const [quoteError, setQuoteError] = useState("");
   const [verifyError, setVerifyError] = useState("");
   const [selectedProviderId, setSelectedProviderId] = useState<string>("paycrest");
 
-  // Track which fields have been touched (blurred) for validation UX
   const [touchedFields, setTouchedFields] = useState<Record<string, boolean>>({});
-
   const touchField = (field: string) =>
     setTouchedFields((prev) => ({ ...prev, [field]: true }));
 
   const quoteDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const verifyDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Reset form when resetKey changes
   useEffect(() => {
     if (resetKey === 0) return;
     setAmount("");
     setFeeMethod("USDC");
     setCurrency("");
     setAccountNumber("");
+    setRoutingNumber("");
+    setIban("");
     setInstitution("");
     setAccountName("");
     setQuote(null);
+    onQuoteChange?.(null);
     setAmountError("");
-    setAccountError("");
     setQuoteError("");
     setVerifyError("");
     setTouchedFields({});
-  }, [resetKey]);
+  }, [resetKey, onQuoteChange]);
 
-  // ---------------------------------------------------------------------------
   // Fetch currencies on mount
-  // -----------------------------------------------------------------------------
   useEffect(() => {
     setIsCurrenciesLoading(true);
     fetch("/api/offramp/currencies")
@@ -584,51 +546,29 @@ export function FormCard({
       .then((data) => {
         if (Array.isArray(data)) {
           setCurrencies(data);
-          // Default to NGN if available (per issue #70)
-          const hasNGN = data.some((c: Currency) => c.code === 'NGN');
+          const hasNGN = data.some((c: Currency) => c.code === "NGN");
           if (hasNGN) {
-            setCurrency('NGN');
+            setCurrency("NGN");
+            onCurrencyChange?.("NGN");
           }
         }
       })
       .catch(() => {})
       .finally(() => setIsCurrenciesLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // ---------------------------------------------------------------------------
-  // Fetch gas fee options on mount (per issue #69)
-  // ---------------------------------------------------------------------------
+  // Fetch gas fee options on mount
   useEffect(() => {
-    const fetchGasFees = async () => {
-      setIsGasFeesLoading(true);
-      try {
-        const res = await fetch('/api/offramp/bridge/gas-fee-options');
-        const data = await res.json();
-        setGasFees(data);
-      } catch (error) {
-        console.error('Failed to fetch gas fees:', error);
-        setGasFees(null);
-      } finally {
-        setIsGasFeesLoading(false);
-      }
-    };
-    fetchGasFees();
-  }, []);
-
-  // ---------------------------------------------------------------------------
-  // Fetch institutions when currency changes
-  // ---------------------------------------------------------------------------
-  useEffect(() => {
-    setIsCurrenciesLoading(true);
-    fetch("/api/offramp/currencies")
+    setIsGasFeesLoading(true);
+    fetch("/api/offramp/bridge/gas-fee-options")
       .then((r) => r.json())
-      .then((data) => {
-        if (Array.isArray(data)) setCurrencies(data);
-      })
-      .catch(() => {})
-      .finally(() => setIsCurrenciesLoading(false));
+      .then((data) => setGasFees(data))
+      .catch(() => setGasFees(null))
+      .finally(() => setIsGasFeesLoading(false));
   }, []);
 
+  // Fetch institutions when currency changes
   useEffect(() => {
     if (!currency) {
       setInstitutions([]);
@@ -649,51 +589,26 @@ export function FormCard({
 
   const fetchQuote = useCallback(
     (amt: string, cur: string, fee: FeeMethod) => {
-      // Clear any pending debounce
       if (quoteDebounceRef.current) clearTimeout(quoteDebounceRef.current);
-
-      // Validate minimum inputs
       const num = parseFloat(amt);
       if (!amt || isNaN(num) || num < 0.7 || !cur) {
         setQuote(null);
         onQuoteChange?.(null);
         return;
       }
-
-      // Debounce 500ms before fetching
       quoteDebounceRef.current = setTimeout(async () => {
         setIsQuoteLoading(true);
         setQuoteError("");
         try {
-          // Call quote API endpoint
           const res = await fetch("/api/offramp/quote", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ 
-              amount: amt, 
-              currency: cur, 
-              feeMethod: fee 
-            }),
+            body: JSON.stringify({ amount: amt, currency: cur, feeMethod: fee }),
           });
-
           const data = await res.json();
-          
-          if (!res.ok) {
-            throw new Error(data.error || "Failed to fetch quote");
-          }
-
-          // Validate quote object - reject NaN or negative values
-          if (!isValidQuote(data)) {
-            throw new Error("Invalid quote received: NaN or negative values");
-          }
-
-          // Build quote result with currency
-          const result: QuoteResult = { 
-            ...data, 
-            currency: cur 
-          };
-
-          // Update state and notify parent
+          if (!res.ok) throw new Error(data.error || "Failed to fetch quote");
+          if (!isValidQuote(data)) throw new Error("Invalid quote received");
+          const result: QuoteResult = { ...data, currency: cur };
           setQuote(result);
           onQuoteChange?.(result);
         } catch (err: unknown) {
@@ -706,18 +621,16 @@ export function FormCard({
         }
       }, 500);
     },
-    [onQuoteChange]
+    [onQuoteChange],
   );
 
   const verifyAccount = useCallback(
     (accNum: string, inst: string, cur: string) => {
       if (verifyDebounceRef.current) clearTimeout(verifyDebounceRef.current);
-
       if (!validateAccountNumber(accNum) || !inst || !cur) {
         setAccountName("");
         return;
       }
-
       verifyDebounceRef.current = setTimeout(async () => {
         setIsVerifyingAccount(true);
         setVerifyError("");
@@ -726,7 +639,11 @@ export function FormCard({
           const res = await fetch("/api/offramp/verify-account", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ institution: inst, accountIdentifier: accNum, currency: cur }),
+            body: JSON.stringify({
+              institution: inst,
+              accountIdentifier: accNum,
+              currency: cur,
+            }),
           });
           const data = await res.json();
           if (!res.ok) throw new Error(data.error || "Verification failed");
@@ -739,162 +656,227 @@ export function FormCard({
         }
       }, 400);
     },
-    []
+    [],
   );
 
-  function handleAmountChange(val: string) {
+  // ---------------------------------------------------------------------------
+  // Event handlers
+  // ---------------------------------------------------------------------------
+
+  const handleAmountChange = (val: string) => {
     setAmount(val);
     onAmountChange?.(val);
-    const num = parseFloat(val);
-    if (val && (isNaN(num) || num < 0.7)) {
+    if (!val) {
+      setAmountError("");
+    } else if (!validateAmount(val)) {
+      setAmountError("Enter a valid number");
+    } else if (parseFloat(val) < 0.7) {
       setAmountError("Minimum amount is 0.7 USDC");
     } else {
       setAmountError("");
     }
     fetchQuote(val, currency, feeMethod);
-  }
+  };
 
-  function handleCurrencyChange(val: string) {
+  const handleCurrencyChange = (val: string) => {
     setCurrency(val);
     onCurrencyChange?.(val);
     fetchQuote(amount, val, feeMethod);
+  };
+
+  const handleInstitutionChange = (val: string) => {
+    setInstitution(val);
+    setAccountName("");
+    setVerifyError("");
+    if (accountNumber) verifyAccount(accountNumber, val, currency);
+  };
+
+  const handleAccountNumberChange = (val: string) => {
+    setAccountNumber(val);
+    verifyAccount(val, institution, currency);
+  };
+
+  const handleFeeMethodChange = (m: FeeMethod) => {
+    setFeeMethod(m);
+    fetchQuote(amount, currency, m);
+  };
+
+  const handleSubmit = async () => {
+    // Mark all fields touched so validation messages appear
+    setTouchedFields({
+      amount: true,
+      currency: true,
+      institution: true,
+      accountNumber: true,
+    });
+
+    if (
+      !amount ||
+      !currency ||
+      !institution ||
+      !accountNumber ||
+      !accountName ||
+      amountError ||
+      verifyError
+    ) {
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      await onSubmit({
+        amount,
+        currency,
+        institution,
+        accountIdentifier: accountNumber,
+        accountName,
+        feeMethod,
+        bankMode,
+        routingNumber: routingNumber || undefined,
+        iban: iban || undefined,
+        quote,
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  if (isInitialLoading) {
+    return <FormCardSkeleton />;
   }
 
-  const ctaLabel = isConnecting
-    ? "CONNECTING..."
+  const ctaState: CtaState = isConnecting
+    ? "connecting"
     : !isConnected
-    ? "CONNECT WALLET"
-    : "INITIATE OFFRAMP →";
+    ? "disconnected"
+    : isSubmitting
+    ? "submitting"
+    : "ready";
 
   const ctaDisabled =
-    isConnecting ||
-    !isConnected ||
-    !amount ||
-    !currency ||
-    !bank ||
-    !accountNumber ||
-    !accountName;
+    ctaState === "connecting" ||
+    ctaState === "submitting" ||
+    (ctaState === "ready" &&
+      (!amount ||
+        !!amountError ||
+        !currency ||
+        !institution ||
+        !accountNumber ||
+        !accountName ||
+        !!verifyError));
 
   return (
-    <div className="flex flex-col gap-6" onKeyDown={handleKeyDown}>
-      <div className="bg-[#111111] border border-[#333333] p-6 flex flex-col gap-6">
-        <InputField
-          label="Amount (USDC)"
-          id="amount"
-          value={amount}
-          onChange={handleAmountChange}
-          onBlur={() => touchField("amount")}
-          type="number"
-          placeholder="0.00"
-          suffix={isQuoteLoading ? "..." : "USDC"}
-          error={amountError || quoteError}
-          success={validateAmount(amount) && parseFloat(amount) >= 0.7 ? "Valid amount" : undefined}
-          touched={touchedFields["amount"]}
-          disabled={!isConnected || isSubmitting}
-        />
+    <section
+      aria-label="Offramp form"
+      className="bg-[#111111] border border-[#333333] p-6 flex flex-col gap-6"
+    >
+      <InputField
+        label="Amount (USDC)"
+        id="amount"
+        value={amount}
+        onChange={handleAmountChange}
+        onBlur={() => touchField("amount")}
+        type="number"
+        placeholder="0.00"
+        suffix={isQuoteLoading ? "..." : "USDC"}
+        error={amountError || quoteError}
+        success={
+          !amountError && validateAmount(amount) && parseFloat(amount) >= 0.7
+            ? "Valid amount"
+            : undefined
+        }
+        touched={touchedFields["amount"]}
+        disabled={!isConnected || isSubmitting}
+        inputMode="decimal"
+        help="Minimum 0.7 USDC. Rate updates live as you type."
+      />
 
       {/* Fee method */}
       <div className="flex flex-col gap-1.5">
-        <Label>Gas Fee Method</Label>
-        {isLoadingFees ? (
+        <span className="text-[10px] tracking-[0.18em] text-[#777777] uppercase">
+          Gas Fee Method
+        </span>
+        {isGasFeesLoading ? (
           <div className="flex gap-2">
             <Skeleton width="50%" height={44} aria-label="Loading fee option…" />
             <Skeleton width="50%" height={44} aria-label="Loading fee option…" />
           </div>
         ) : (
           <div className="flex gap-2">
-            {feeOptions.map((opt) => (
-              <button
-                key={opt.method}
-                type="button"
-                aria-label={opt.label}
-                onClick={() => onFeeMethodChange(opt.method)}
-                disabled={!isConnected}
-                className={cn(
-                  "flex-1 py-2.5 px-3 text-xs tracking-widest border transition-colors duration-150",
-                  "focus:outline-none focus-visible:ring-1 focus-visible:ring-accent",
-                  "disabled:opacity-40 disabled:cursor-not-allowed",
-                  feeMethod === opt.method
-                    ? "border-accent bg-accent/10 text-accent"
-                    : "border-line bg-bg text-muted hover:border-accent/50"
-                )}
-              >
-                <span className="block font-semibold">{opt.label}</span>
-                <span className="block text-[10px] mt-0.5 opacity-80">{opt.amount}</span>
-              </button>
-            ))}
+            {(["USDC", "XLM"] as FeeMethod[]).map((m) => {
+              const fee = m === "USDC" ? gasFees?.usdcFee : gasFees?.xlmFee;
+              const active = feeMethod === m;
+              return (
+                <button
+                  key={m}
+                  type="button"
+                  onClick={() => handleFeeMethodChange(m)}
+                  disabled={!isConnected || isSubmitting}
+                  className={cn(
+                    "flex-1 py-2.5 px-3 min-h-[44px] text-xs tracking-widest border transition-colors duration-150",
+                    "focus:outline-none focus-visible:ring-1 focus-visible:ring-[#c9a962]",
+                    "disabled:opacity-40 disabled:cursor-not-allowed",
+                    active
+                      ? "border-[#c9a962] bg-[#c9a962]/10 text-[#c9a962]"
+                      : "border-[#333333] bg-[#0a0a0a] text-[#777777] hover:border-[#c9a962]/50",
+                  )}
+                >
+                  <span className="block font-semibold">{m}</span>
+                  {fee && <span className="block text-[10px] mt-0.5 opacity-80">{fee}</span>}
+                </button>
+              );
+            })}
           </div>
         )}
+        <p className="text-[10px] text-[#666666] leading-relaxed">
+          {feeMethod === "XLM"
+            ? "XLM will be used to cover Stellar network fees."
+            : "A small USDC amount will be deducted to cover network fees."}
+        </p>
       </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <SelectField
-            label="Currency"
-            id="currency"
-            value={currency}
-            options={currencies.map((c) => {
-              const flag = getCurrencyFlag(c.code);
-              return { value: c.code, label: flag ? `${flag} ${c.name} (${c.code})` : `${c.name} (${c.code})` };
-            })}
-            onChange={handleCurrencyChange}
-            onBlur={() => touchField("currency")}
-            loading={isCurrenciesLoading}
-            disabled={!isConnected || isSubmitting}
-            error="Please select a currency"
-            touched={touchedFields["currency"]}
-          />
-          <SelectField
-            label="Bank / Institution"
-            id="institution"
-            value={institution}
-            options={institutions.map((i) => ({ value: i.code, label: i.name }))}
-            onChange={handleInstitutionChange}
-            onBlur={() => touchField("institution")}
-            loading={isInstitutionsLoading}
-            disabled={!currency || !isConnected || isSubmitting}
-            placeholder={currency ? "Select bank..." : "Select currency first"}
-            error="Please select a bank"
-            touched={touchedFields["institution"]}
-          />
-        </div>
-
-        {/* Bank */}
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor="bank">Bank / Institution</Label>
-          {isLoadingBanks ? (
-            <Skeleton width="100%" height={42} aria-label="Loading bank options…" />
-          ) : (
-            <select
-              id="bank"
-              aria-label="BANK"
-              value={bank}
-              onChange={(e) => onBankChange(e.target.value)}
-              disabled={!isConnected || !currency}
-              className={cn(
-                "w-full appearance-none bg-bg border border-line px-3 py-2.5 text-sm",
-                "focus:outline-none focus-visible:ring-1 focus-visible:ring-accent focus:border-accent",
-                "disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150",
-                bank ? "text-text" : "text-[#444444]"
-              )}
-            >
-              <option value="" disabled>{currency ? "Select bank..." : "Select currency first"}</option>
-              {banks.map((b) => (
-                <option key={b.value} value={b.value}>{b.label}</option>
-              ))}
-            </select>
-          )}
-        </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <SelectField
+          label="Currency"
+          id="currency"
+          value={currency}
+          options={currencies.map((c) => {
+            const flag = getCurrencyFlag(c.code);
+            return {
+              value: c.code,
+              label: flag ? `${flag} ${c.name} (${c.code})` : `${c.name} (${c.code})`,
+            };
+          })}
+          onChange={handleCurrencyChange}
+          onBlur={() => touchField("currency")}
+          loading={isCurrenciesLoading}
+          disabled={!isConnected || isSubmitting}
+          error="Please select a currency"
+          touched={touchedFields["currency"]}
+        />
+        <SelectField
+          label="Bank / Institution"
+          id="institution"
+          value={institution}
+          options={institutions.map((i) => ({ value: i.code, label: i.name }))}
+          onChange={handleInstitutionChange}
+          onBlur={() => touchField("institution")}
+          loading={isInstitutionsLoading}
+          disabled={!currency || !isConnected || isSubmitting}
+          placeholder={currency ? "Select bank..." : "Select currency first"}
+          error="Please select a bank"
+          touched={touchedFields["institution"]}
+        />
       </div>
 
-      {/* Account number */}
       <BankAccountInput
         mode={bankMode}
         onModeChange={setBankMode}
         accountNumber={accountNumber}
-        onAccountNumberChange={(v) => {
-          setAccountNumber(v);
-          verifyAccount(v, institution, currency);
-        }}
+        onAccountNumberChange={handleAccountNumberChange}
         routingNumber={routingNumber}
         onRoutingNumberChange={setRoutingNumber}
         iban={iban}
@@ -902,52 +884,47 @@ export function FormCard({
         disabled={!institution || !isConnected || isSubmitting}
       />
 
-        <Field label="Account Name" value={accountName} loading={isVerifyingAccount} success={!!accountName} />
+      {verifyError && (
+        <span role="alert" className="text-[10px] text-red-400 tracking-wide">
+          {verifyError}
+        </span>
+      )}
 
-        {quote && <PayoutBox quote={quote} currency={currency} liveRate={liveRate} flash={rateFlash} />}
+      <ResolvedField
+        label="Account Name"
+        value={accountName}
+        loading={isVerifyingAccount}
+        placeholder={accountNumber ? "Verifying…" : "Enter account number to verify"}
+      />
 
-        {quote && (
-          <QuoteComparison
-            quotes={buildProviderQuotes(quote, currency)}
-            selectedId={selectedProviderId}
-            onSelect={setSelectedProviderId}
-            isLoading={isQuoteLoading}
-          />
-        )}
+      {quote && (
+        <PayoutBox quote={quote} currency={currency} liveRate={liveRate} flash={rateFlash} />
+      )}
 
-        <button
-          onClick={ctaState === "disconnected" ? onConnect : handleSubmitForm}
-          disabled={getCtaDisabled(ctaState)}
-          aria-label={getCtaLabel(ctaState)}
-          className={cn(
-            "w-full py-4 min-h-[52px] text-xs font-bold tracking-[0.2em] transition-all duration-200",
-            "focus:outline-none focus-visible:ring-2 focus-visible:ring-[#c9a962] focus-visible:ring-offset-2 focus-visible:ring-offset-[#111111]",
-            ctaState === "ready"
-              ? "bg-[#c9a962] text-black hover:bg-[#d4b982]"
-              : "bg-[#222222] text-[#555555] cursor-not-allowed border border-[#333333]",
-            (ctaState === "connecting" || ctaState === "submitting") && "animate-pulse"
-          )}
-        >
-          {getCtaLabel(ctaState)}
-        </button>
-      </div>
+      {quote && (
+        <QuoteComparison
+          quotes={buildProviderQuotes(quote, currency)}
+          selectedId={selectedProviderId}
+          onSelect={setSelectedProviderId}
+          isLoading={isQuoteLoading}
+        />
+      )}
 
-      {/* CTA */}
       <button
         type="button"
-        onClick={onSubmit}
+        onClick={ctaState === "disconnected" ? onConnect : handleSubmit}
         disabled={ctaDisabled}
-        aria-label={ctaLabel}
+        aria-label={getCtaLabel(ctaState)}
         className={cn(
-          "w-full py-4 text-xs font-bold tracking-[0.2em] transition-all duration-200",
-          "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
-          !ctaDisabled
-            ? "bg-accent text-black hover:bg-[#d4b982]"
-            : "bg-[#222222] text-[#555555] cursor-not-allowed border border-line",
-          isConnecting && "animate-pulse"
+          "w-full py-4 min-h-[52px] text-xs font-bold tracking-[0.2em] transition-all duration-200",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-[#c9a962] focus-visible:ring-offset-2 focus-visible:ring-offset-[#111111]",
+          ctaState === "ready" && !ctaDisabled
+            ? "bg-[#c9a962] text-black hover:bg-[#d4b982]"
+            : "bg-[#222222] text-[#555555] cursor-not-allowed border border-[#333333]",
+          (ctaState === "connecting" || ctaState === "submitting") && "animate-pulse",
         )}
       >
-        {ctaLabel}
+        {getCtaLabel(ctaState)}
       </button>
     </section>
   );

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -9,7 +9,14 @@ import type { OfframpStep } from "@/types/stellaramp";
 // Config
 // ---------------------------------------------------------------------------
 
-type TransactionStatus = RecentOfframpRow["status"] | OfframpStep | "pending" | "completed" | "failed";
+type TransactionStatus =
+  | RecentOfframpRow["status"]
+  | OfframpStep
+  | "pending"
+  | "completed"
+  | "failed"
+  | "reversed"
+  | "partially_reversed";
 
 interface StatusConfig {
   label: string;
@@ -107,6 +114,18 @@ const STATUS_CONFIG: Record<string, StatusConfig> = {
     tooltip: "Transaction failed.",
     colorClasses: "bg-red-500/10 border border-red-500/40 text-red-400",
     dotClasses: "bg-red-500",
+  },
+  reversed: {
+    label: "Reversed",
+    tooltip: "Transaction was fully reversed.",
+    colorClasses: "bg-purple-500/10 border border-purple-500/40 text-purple-400",
+    dotClasses: "bg-purple-500",
+  },
+  partially_reversed: {
+    label: "Partially Reversed",
+    tooltip: "Part of the transaction was reversed.",
+    colorClasses: "bg-purple-500/10 border border-purple-500/40 text-purple-400",
+    dotClasses: "bg-purple-500",
   },
 };
 

--- a/src/components/skeletons/AnalyticsDashboardSkeleton.tsx
+++ b/src/components/skeletons/AnalyticsDashboardSkeleton.tsx
@@ -1,0 +1,105 @@
+import { Skeleton } from "@/components/ui/Skeleton";
+
+/**
+ * Skeleton for AnalyticsDashboard while analytics data is being fetched.
+ * Mirrors the period selector, metric cards, funnel, currency breakdown,
+ * fee analysis, and spending patterns sections so there's no layout shift.
+ */
+export function AnalyticsDashboardSkeleton() {
+  return (
+    <div
+      aria-label="Loading analytics"
+      aria-busy="true"
+      className="space-y-6"
+    >
+      {/* Period selector */}
+      <div className="flex gap-2">
+        <Skeleton width={110} height={36} aria-label="Loading period option…" />
+        <Skeleton width={110} height={36} aria-label="Loading period option…" />
+        <Skeleton width={110} height={36} aria-label="Loading period option…" />
+      </div>
+
+      {/* Metric cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="bg-white p-4 rounded-lg border flex flex-col gap-2"
+          >
+            <Skeleton width="60%" height={12} aria-label="Loading metric label…" />
+            <Skeleton width="80%" height={24} aria-label="Loading metric value…" />
+          </div>
+        ))}
+      </div>
+
+      {/* Funnel block */}
+      <div className="bg-gray-900 p-6 rounded-lg border border-gray-700">
+        <div className="flex items-center justify-between mb-4">
+          <Skeleton width={180} height={18} aria-label="Loading funnel title…" />
+          <Skeleton width={100} height={14} aria-label="Loading funnel meta…" />
+        </div>
+        <div className="flex flex-col gap-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton
+              key={i}
+              width={`${100 - i * 15}%`}
+              height={28}
+              aria-label="Loading funnel step…"
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Currency breakdown */}
+      <div className="bg-white p-6 rounded-lg border">
+        <Skeleton width={180} height={18} className="mb-4" aria-label="Loading section title…" />
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="flex items-center justify-between">
+              <div className="flex flex-col gap-1.5">
+                <Skeleton width={60} height={14} aria-label="Loading currency…" />
+                <Skeleton width={100} height={11} aria-label="Loading transaction count…" />
+              </div>
+              <div className="flex flex-col items-end gap-1.5">
+                <Skeleton width={80} height={14} aria-label="Loading volume…" />
+                <Skeleton width={40} height={11} aria-label="Loading percentage…" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Fee analysis */}
+      <div className="bg-white p-6 rounded-lg border">
+        <Skeleton width={140} height={18} className="mb-4" aria-label="Loading section title…" />
+        <div className="grid grid-cols-2 gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex flex-col gap-1.5">
+              <Skeleton width="70%" height={11} aria-label="Loading fee label…" />
+              <Skeleton width="50%" height={22} aria-label="Loading fee value…" />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Spending patterns */}
+      <div className="bg-white p-6 rounded-lg border">
+        <Skeleton width={180} height={18} className="mb-4" aria-label="Loading section title…" />
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center justify-between py-2 border-b"
+            >
+              <div className="flex flex-col gap-1.5">
+                <Skeleton width={100} height={14} aria-label="Loading date…" />
+                <Skeleton width={140} height={11} aria-label="Loading transaction count…" />
+              </div>
+              <Skeleton width={70} height={16} aria-label="Loading amount…" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/skeletons/BankAccountInputSkeleton.tsx
+++ b/src/components/skeletons/BankAccountInputSkeleton.tsx
@@ -1,0 +1,31 @@
+import { Skeleton } from "@/components/ui/Skeleton";
+
+/**
+ * Skeleton for BankAccountInput while bank metadata (mode + field shape)
+ * is loading. Renders three mode tabs and a single field row to match
+ * the most common (Local) layout.
+ */
+export function BankAccountInputSkeleton({ fields = 1 }: { fields?: 1 | 2 }) {
+  return (
+    <div
+      aria-label="Loading bank account input"
+      aria-busy="true"
+      className="flex flex-col gap-3"
+    >
+      {/* Mode tabs */}
+      <div className="flex gap-4 border-b border-[#333333] pb-1">
+        <Skeleton width={50} height={14} aria-label="Loading mode tab…" />
+        <Skeleton width={70} height={14} aria-label="Loading mode tab…" />
+        <Skeleton width={50} height={14} aria-label="Loading mode tab…" />
+      </div>
+
+      {/* Field rows */}
+      {Array.from({ length: fields }).map((_, i) => (
+        <div key={i} className="flex flex-col gap-1.5">
+          <Skeleton width={110} height={11} aria-label="Loading field label…" />
+          <Skeleton width="100%" height={46} aria-label="Loading field input…" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/skeletons/index.ts
+++ b/src/components/skeletons/index.ts
@@ -2,3 +2,5 @@ export { FormCardSkeleton } from "./FormCardSkeleton";
 export { TransactionTableSkeleton } from "./TransactionTableSkeleton";
 export { QuoteDisplaySkeleton } from "./QuoteDisplaySkeleton";
 export { WalletConnectionSkeleton } from "./WalletConnectionSkeleton";
+export { AnalyticsDashboardSkeleton } from "./AnalyticsDashboardSkeleton";
+export { BankAccountInputSkeleton } from "./BankAccountInputSkeleton";

--- a/src/lib/transaction-storage.ts
+++ b/src/lib/transaction-storage.ts
@@ -130,4 +130,21 @@ export class TransactionStorage {
   static getFavoritesByUser(userAddress: string): Transaction[] {
     return this.getByUser(userAddress).filter(tx => tx.isFavorite);
   }
+
+  /**
+   * Apply an update locally and return a rollback function that restores
+   * the previous values. Use when the caller is also issuing a network
+   * request and wants to revert the local change if it fails.
+   */
+  static applyOptimistic(id: string, updates: Partial<Transaction>): () => void {
+    const prior = this.getById(id);
+    if (!prior) return () => {};
+    const snapshot: Partial<Transaction> = {};
+    for (const key of Object.keys(updates) as Array<keyof Transaction>) {
+      // Save the previous value for every key being changed so rollback is exact.
+      (snapshot as Record<string, unknown>)[key] = prior[key];
+    }
+    this.update(id, updates);
+    return () => this.update(id, snapshot);
+  }
 }


### PR DESCRIPTION
#438 — Skeletons: add AnalyticsDashboardSkeleton + BankAccountInputSkeleton, wire analytics skeleton in, add shimmer overlay on top of the existing pulse animation (respects prefers-reduced-motion).

#439 — Optimistic UI: FavoriteButton flips immediately and rolls back on error with inline message; history-page note save PATCHes the server with rollback of UI + local storage on failure; new TransactionStorage.applyOptimistic helper returns a rollback closure.

#440 — Form validation: rewrote FormCard.tsx (was broken on main with unresolved duplicate code from a botched merge). Adds real-time amount validation with 500ms debounced quote fetch, 400ms debounced async account verification, inline error/success with aria-describedby, valid/invalid icons, spinner during async validation, and field-level help text. Extended OfframpPayload with accountIdentifier and quote to match call sites.

#441 — Filtering & sorting: added currency filter (distinct currencies from the user's transactions), status sort, filter-count badge in the Filters header, and localStorage persistence of filter preferences. Fixed pre-existing StatusBadge import conflict and added reversed / partially_reversed status configs.

Closes #438 
Closes #439 
Closes #440 
Closes #441 