### PR TITLE
feat(cdn): implement CloudFront CDN distribution

### DIFF
--- a/docs/cdn.md
+++ b/docs/cdn.md
@@ -1,0 +1,178 @@
+# CDN Setup — CloudFront
+
+Stellar-Spend uses Amazon CloudFront as its CDN to serve static assets globally with low latency and to terminate TLS at the edge.
+
+---
+
+## Architecture
+
+```
+Browser → CloudFront (edge) → ALB → ECS Fargate (Next.js)
+```
+
+- **Static assets** (`/_next/static/*`, `/static/*`, `/icons/*`) are cached at the edge for 1 year (immutable).
+- **Pages** are cached for up to 1 hour with short TTLs.
+- **API routes** (`/api/*`) bypass the cache entirely — all requests are forwarded to the origin.
+- A **CloudFront Function** injects security headers (`HSTS`, `X-Frame-Options`, etc.) on every response.
+
+---
+
+## Terraform resources
+
+All CDN infrastructure is defined in [`terraform/cloudfront.tf`](../terraform/cloudfront.tf).
+
+| Resource | Purpose |
+|---|---|
+| `aws_cloudfront_distribution.main` | Main distribution, ALB as origin |
+| `aws_cloudfront_cache_policy.static_assets` | 1-year immutable cache for `_next/static` |
+| `aws_cloudfront_cache_policy.pages` | Short TTL (60 s default, 1 h max) for pages |
+| `aws_cloudfront_cache_policy.no_cache` | Zero TTL for API routes |
+| `aws_cloudfront_origin_request_policy.alb_forward` | Forwards required headers to ALB |
+| `aws_cloudfront_function.security_headers` | Injects HSTS and other security headers |
+| `aws_s3_bucket.cf_logs` | Stores CloudFront access logs |
+| `null_resource.cf_invalidation` | Triggers a `/*` invalidation on deploy |
+| `aws_cloudwatch_metric_alarm.cf_5xx_rate` | Alarm when 5xx rate > 5% |
+| `aws_cloudwatch_metric_alarm.cf_4xx_rate` | Alarm when 4xx rate > 10% |
+| `aws_cloudwatch_metric_alarm.cf_origin_latency` | Alarm when p99 origin latency > 3 s |
+
+---
+
+## Variables
+
+Add these to your `terraform/envs/<env>.tfvars` or supply via `TF_VAR_*` environment variables.
+
+| Variable | Default | Description |
+|---|---|---|
+| `cf_price_class` | `PriceClass_100` | Edge locations: `PriceClass_100` (US/EU), `PriceClass_200` (+ Asia), `PriceClass_All` |
+| `cf_domain_aliases` | `[]` | Custom domains (e.g. `["cdn.example.com"]`). Requires `cf_acm_certificate_arn`. |
+| `cf_acm_certificate_arn` | `""` | ACM certificate ARN in **us-east-1** for custom domains |
+| `cf_origin_secret` | — | Shared secret sent as `X-CloudFront-Secret` header to the ALB |
+| `cf_geo_restriction_type` | `blacklist` | `whitelist` or `blacklist` |
+| `cf_geo_restriction_locations` | `[]` | ISO 3166-1 alpha-2 country codes. Empty = no restriction |
+| `cf_invalidation_trigger` | `initial` | Bump to force a cache invalidation on next `terraform apply` |
+| `alarm_sns_arn` | `""` | SNS topic ARN for CloudWatch alarm notifications |
+
+---
+
+## Outputs
+
+After `terraform apply`, the following outputs are available:
+
+| Output | Description |
+|---|---|
+| `cloudfront_distribution_id` | Distribution ID — use for manual invalidations |
+| `cloudfront_domain_name` | Default CF domain (e.g. `https://d1234.cloudfront.net`) |
+| `cloudfront_hosted_zone_id` | Hosted zone ID for Route 53 alias records |
+| `cf_logs_bucket` | S3 bucket name for access logs |
+
+---
+
+## Environment variable
+
+Set `NEXT_PUBLIC_CDN_URL` to the CloudFront domain so Next.js serves static assets from the CDN:
+
+```bash
+# .env.local (or ECS task environment)
+NEXT_PUBLIC_CDN_URL=https://d1234.cloudfront.net
+```
+
+The value is automatically available from Terraform:
+
+```bash
+terraform output cloudfront_domain_name
+```
+
+---
+
+## Deploying
+
+### First deploy
+
+```bash
+cd terraform
+terraform init
+terraform apply -var-file=envs/staging.tfvars \
+  -var="cf_origin_secret=$CF_ORIGIN_SECRET" \
+  -var="paycrest_api_key=$PAYCREST_API_KEY" \
+  # ... other secrets
+```
+
+### Custom domain (optional)
+
+1. Create an ACM certificate in **us-east-1** for your CDN domain.
+2. Set `cf_domain_aliases = ["cdn.example.com"]` and `cf_acm_certificate_arn = "arn:aws:acm:..."`.
+3. Create a Route 53 CNAME or alias record pointing to `cloudfront_domain_name`.
+
+### Cache invalidation
+
+Invalidations run automatically on every `terraform apply` when `cf_invalidation_trigger` changes.
+
+To invalidate manually:
+
+```bash
+aws cloudfront create-invalidation \
+  --distribution-id $(terraform output -raw cloudfront_distribution_id) \
+  --paths "/*"
+```
+
+To trigger via Terraform, bump the variable:
+
+```bash
+terraform apply -var="cf_invalidation_trigger=$(date +%s)" -var-file=envs/staging.tfvars
+```
+
+---
+
+## Security
+
+### Origin protection
+
+The ALB only accepts requests that include the `X-CloudFront-Secret` header. Configure an ALB listener rule to block requests missing this header:
+
+```hcl
+# Add to main.tf ALB listener rule
+condition {
+  http_header {
+    http_header_name = "X-CloudFront-Secret"
+    values           = [var.cf_origin_secret]
+  }
+}
+```
+
+### TLS
+
+- CloudFront enforces HTTPS (`redirect-to-https` viewer protocol policy).
+- Minimum TLS version: **TLSv1.2_2021** when using custom domains.
+- HSTS header (`max-age=63072000; includeSubDomains; preload`) is injected by the CloudFront Function.
+
+### Geo-restrictions
+
+To block specific countries, set:
+
+```hcl
+cf_geo_restriction_type      = "blacklist"
+cf_geo_restriction_locations = ["KP", "IR", "CU"]
+```
+
+To allow only specific countries (whitelist mode):
+
+```hcl
+cf_geo_restriction_type      = "whitelist"
+cf_geo_restriction_locations = ["NG", "KE", "GH", "US", "GB"]
+```
+
+---
+
+## Monitoring
+
+Three CloudWatch alarms are created automatically:
+
+| Alarm | Threshold | Action |
+|---|---|---|
+| `cf-5xx-rate` | > 5% for 10 min | SNS notification |
+| `cf-4xx-rate` | > 10% for 15 min | SNS notification |
+| `cf-origin-latency` | p99 > 3 s for 10 min | SNS notification |
+
+Set `alarm_sns_arn` to receive notifications. CloudFront metrics are published to the `us-east-1` region under the `AWS/CloudFront` namespace.
+
+Access logs are stored in the `<env>-cf-logs` S3 bucket and expire after 90 days (production) or 30 days (staging).

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -1,0 +1,364 @@
+# ── CloudFront CDN ────────────────────────────────────────────────────────────
+# Distributes static assets and optionally the full app via CloudFront.
+# Origin: Application Load Balancer (ALB).
+
+locals {
+  cf_origin_id = "${local.name_prefix}-alb-origin"
+}
+
+# ── S3 bucket for CloudFront access logs ─────────────────────────────────────
+
+resource "aws_s3_bucket" "cf_logs" {
+  bucket        = "${local.name_prefix}-cf-logs"
+  force_destroy = var.environment != "production"
+
+  tags = { Name = "${local.name_prefix}-cf-logs" }
+}
+
+resource "aws_s3_bucket_ownership_controls" "cf_logs" {
+  bucket = aws_s3_bucket.cf_logs.id
+  rule { object_ownership = "BucketOwnerPreferred" }
+}
+
+resource "aws_s3_bucket_acl" "cf_logs" {
+  depends_on = [aws_s3_bucket_ownership_controls.cf_logs]
+  bucket     = aws_s3_bucket.cf_logs.id
+  acl        = "log-delivery-write"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "cf_logs" {
+  bucket = aws_s3_bucket.cf_logs.id
+
+  rule {
+    id     = "expire-old-logs"
+    status = "Enabled"
+    expiration { days = var.environment == "production" ? 90 : 30 }
+  }
+}
+
+# ── Cache policies ────────────────────────────────────────────────────────────
+
+# Immutable static assets (_next/static, /static) — cache 1 year
+resource "aws_cloudfront_cache_policy" "static_assets" {
+  name        = "${local.name_prefix}-static-assets"
+  min_ttl     = 31536000
+  default_ttl = 31536000
+  max_ttl     = 31536000
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config { cookie_behavior = "none" }
+    headers_config { header_behavior = "none" }
+    query_strings_config { query_string_behavior = "none" }
+    enable_accept_encoding_brotli = true
+    enable_accept_encoding_gzip   = true
+  }
+}
+
+# Dynamic / API responses — no caching, forward all
+resource "aws_cloudfront_cache_policy" "no_cache" {
+  name        = "${local.name_prefix}-no-cache"
+  min_ttl     = 0
+  default_ttl = 0
+  max_ttl     = 0
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config { cookie_behavior = "all" }
+    headers_config {
+      header_behavior = "whitelist"
+      headers {
+        items = [
+          "Authorization",
+          "Host",
+          "Origin",
+          "Referer",
+          "Accept",
+          "Accept-Language",
+          "Content-Type",
+        ]
+      }
+    }
+    query_strings_config { query_string_behavior = "all" }
+    enable_accept_encoding_brotli = false
+    enable_accept_encoding_gzip   = false
+  }
+}
+
+# Public pages — short cache with revalidation
+resource "aws_cloudfront_cache_policy" "pages" {
+  name        = "${local.name_prefix}-pages"
+  min_ttl     = 0
+  default_ttl = 60
+  max_ttl     = 3600
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config { cookie_behavior = "none" }
+    headers_config { header_behavior = "none" }
+    query_strings_config { query_string_behavior = "none" }
+    enable_accept_encoding_brotli = true
+    enable_accept_encoding_gzip   = true
+  }
+}
+
+# ── Origin request policy (forward necessary headers to ALB) ──────────────────
+
+resource "aws_cloudfront_origin_request_policy" "alb_forward" {
+  name = "${local.name_prefix}-alb-forward"
+
+  cookies_config { cookie_behavior = "all" }
+  headers_config {
+    header_behavior = "whitelist"
+    headers {
+      items = [
+        "Host",
+        "Origin",
+        "Referer",
+        "Accept",
+        "Accept-Language",
+        "Accept-Encoding",
+        "Content-Type",
+        "X-Forwarded-For",
+        "CloudFront-Viewer-Country",
+      ]
+    }
+  }
+  query_strings_config { query_string_behavior = "all" }
+}
+
+# ── CloudFront distribution ───────────────────────────────────────────────────
+
+resource "aws_cloudfront_distribution" "main" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "${local.name_prefix} CDN"
+  price_class         = var.cf_price_class
+  aliases             = var.cf_domain_aliases
+  http_version        = "http2and3"
+  wait_for_deployment = false
+
+  # ── Origin: ALB ──────────────────────────────────────────────────────────
+
+  origin {
+    domain_name = aws_lb.main.dns_name
+    origin_id   = local.cf_origin_id
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only" # ALB listener is HTTP; TLS terminates at CF
+      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_read_timeout    = 60
+      origin_keepalive_timeout = 60
+    }
+
+    custom_header {
+      name  = "X-CloudFront-Secret"
+      value = var.cf_origin_secret
+    }
+  }
+
+  # ── Default behaviour: dynamic pages ─────────────────────────────────────
+
+  default_cache_behavior {
+    target_origin_id         = local.cf_origin_id
+    viewer_protocol_policy   = "redirect-to-https"
+    allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods           = ["GET", "HEAD"]
+    cache_policy_id          = aws_cloudfront_cache_policy.pages.id
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.alb_forward.id
+    compress                 = true
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.security_headers.arn
+    }
+  }
+
+  # ── Immutable static assets: _next/static ────────────────────────────────
+
+  ordered_cache_behavior {
+    path_pattern             = "/_next/static/*"
+    target_origin_id         = local.cf_origin_id
+    viewer_protocol_policy   = "redirect-to-https"
+    allowed_methods          = ["GET", "HEAD"]
+    cached_methods           = ["GET", "HEAD"]
+    cache_policy_id          = aws_cloudfront_cache_policy.static_assets.id
+    compress                 = true
+  }
+
+  # ── Public static files ───────────────────────────────────────────────────
+
+  ordered_cache_behavior {
+    path_pattern             = "/static/*"
+    target_origin_id         = local.cf_origin_id
+    viewer_protocol_policy   = "redirect-to-https"
+    allowed_methods          = ["GET", "HEAD"]
+    cached_methods           = ["GET", "HEAD"]
+    cache_policy_id          = aws_cloudfront_cache_policy.static_assets.id
+    compress                 = true
+  }
+
+  # ── Public directory (icons, manifest, sw.js) ─────────────────────────────
+
+  ordered_cache_behavior {
+    path_pattern             = "/icons/*"
+    target_origin_id         = local.cf_origin_id
+    viewer_protocol_policy   = "redirect-to-https"
+    allowed_methods          = ["GET", "HEAD"]
+    cached_methods           = ["GET", "HEAD"]
+    cache_policy_id          = aws_cloudfront_cache_policy.static_assets.id
+    compress                 = true
+  }
+
+  # ── API routes: no caching ────────────────────────────────────────────────
+
+  ordered_cache_behavior {
+    path_pattern             = "/api/*"
+    target_origin_id         = local.cf_origin_id
+    viewer_protocol_policy   = "redirect-to-https"
+    allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods           = ["GET", "HEAD"]
+    cache_policy_id          = aws_cloudfront_cache_policy.no_cache.id
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.alb_forward.id
+    compress                 = true
+  }
+
+  # ── Geo-restrictions ──────────────────────────────────────────────────────
+
+  restrictions {
+    geo_restriction {
+      restriction_type = length(var.cf_geo_restriction_locations) > 0 ? var.cf_geo_restriction_type : "none"
+      locations        = var.cf_geo_restriction_locations
+    }
+  }
+
+  # ── SSL/TLS ───────────────────────────────────────────────────────────────
+
+  viewer_certificate {
+    # Use ACM certificate when aliases are configured; otherwise use default CF cert
+    acm_certificate_arn            = length(var.cf_domain_aliases) > 0 ? var.cf_acm_certificate_arn : null
+    cloudfront_default_certificate = length(var.cf_domain_aliases) == 0
+    ssl_support_method             = length(var.cf_domain_aliases) > 0 ? "sni-only" : null
+    minimum_protocol_version       = length(var.cf_domain_aliases) > 0 ? "TLSv1.2_2021" : null
+  }
+
+  # ── Access logging ────────────────────────────────────────────────────────
+
+  logging_config {
+    bucket          = aws_s3_bucket.cf_logs.bucket_domain_name
+    include_cookies = false
+    prefix          = "cloudfront/"
+  }
+
+  tags = { Name = "${local.name_prefix}-cf" }
+
+  depends_on = [aws_cloudfront_function.security_headers]
+}
+
+# ── CloudFront Function: security headers ─────────────────────────────────────
+
+resource "aws_cloudfront_function" "security_headers" {
+  name    = "${local.name_prefix}-security-headers"
+  runtime = "cloudfront-js-2.0"
+  publish = true
+  comment = "Inject security headers on viewer response"
+
+  code = <<-EOF
+    async function handler(event) {
+      const response = event.response;
+      const headers = response.headers;
+
+      headers['strict-transport-security'] = { value: 'max-age=63072000; includeSubDomains; preload' };
+      headers['x-content-type-options']    = { value: 'nosniff' };
+      headers['x-frame-options']           = { value: 'DENY' };
+      headers['referrer-policy']           = { value: 'strict-origin-when-cross-origin' };
+      headers['permissions-policy']        = { value: 'camera=(), microphone=(), geolocation=(), payment=(), usb=()' };
+
+      return response;
+    }
+  EOF
+}
+
+# ── Cache invalidation via AWS CLI (null_resource) ────────────────────────────
+# Run: terraform apply -target=null_resource.cf_invalidation to trigger manually.
+
+resource "null_resource" "cf_invalidation" {
+  triggers = {
+    distribution_id = aws_cloudfront_distribution.main.id
+    # Bump this value to force a new invalidation on next apply
+    invalidation_trigger = var.cf_invalidation_trigger
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      aws cloudfront create-invalidation \
+        --distribution-id ${aws_cloudfront_distribution.main.id} \
+        --paths "/*" \
+        --region ${var.aws_region}
+    EOT
+  }
+
+  depends_on = [aws_cloudfront_distribution.main]
+}
+
+# ── CloudWatch monitoring ─────────────────────────────────────────────────────
+
+resource "aws_cloudwatch_metric_alarm" "cf_5xx_rate" {
+  alarm_name          = "${local.name_prefix}-cf-5xx-rate"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "5xxErrorRate"
+  namespace           = "AWS/CloudFront"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 5
+  alarm_description   = "CloudFront 5xx error rate > 5% for 10 minutes"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DistributionId = aws_cloudfront_distribution.main.id
+    Region         = "Global"
+  }
+
+  alarm_actions = var.alarm_sns_arn != "" ? [var.alarm_sns_arn] : []
+  ok_actions    = var.alarm_sns_arn != "" ? [var.alarm_sns_arn] : []
+}
+
+resource "aws_cloudwatch_metric_alarm" "cf_4xx_rate" {
+  alarm_name          = "${local.name_prefix}-cf-4xx-rate"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "4xxErrorRate"
+  namespace           = "AWS/CloudFront"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 10
+  alarm_description   = "CloudFront 4xx error rate > 10% for 15 minutes"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DistributionId = aws_cloudfront_distribution.main.id
+    Region         = "Global"
+  }
+
+  alarm_actions = var.alarm_sns_arn != "" ? [var.alarm_sns_arn] : []
+}
+
+resource "aws_cloudwatch_metric_alarm" "cf_origin_latency" {
+  alarm_name          = "${local.name_prefix}-cf-origin-latency"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "OriginLatency"
+  namespace           = "AWS/CloudFront"
+  period              = 300
+  statistic           = "p99"
+  threshold           = 3000
+  alarm_description   = "CloudFront p99 origin latency > 3s for 10 minutes"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DistributionId = aws_cloudfront_distribution.main.id
+    Region         = "Global"
+  }
+
+  alarm_actions = var.alarm_sns_arn != "" ? [var.alarm_sns_arn] : []
+}

--- a/terraform/envs/staging.tfvars
+++ b/terraform/envs/staging.tfvars
@@ -30,3 +30,12 @@ stellar_usdc_issuer     = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4K
 # paycrest_webhook_secret = set via TF_VAR_paycrest_webhook_secret
 # base_private_key        = set via TF_VAR_base_private_key
 # database_url            = set via TF_VAR_database_url
+
+# CDN / CloudFront
+cf_price_class               = "PriceClass_100"
+cf_domain_aliases            = []
+cf_acm_certificate_arn       = ""
+cf_geo_restriction_type      = "blacklist"
+cf_geo_restriction_locations = []
+cf_invalidation_trigger      = "initial"
+# cf_origin_secret = set via TF_VAR_cf_origin_secret

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -38,3 +38,23 @@ output "cloudwatch_log_group" {
   description = "CloudWatch log group name for app logs"
   value       = aws_cloudwatch_log_group.app.name
 }
+
+output "cloudfront_distribution_id" {
+  description = "CloudFront distribution ID (use for cache invalidations)"
+  value       = aws_cloudfront_distribution.main.id
+}
+
+output "cloudfront_domain_name" {
+  description = "Default CloudFront domain name (e.g. d1234.cloudfront.net) — set as NEXT_PUBLIC_CDN_URL"
+  value       = "https://${aws_cloudfront_distribution.main.domain_name}"
+}
+
+output "cloudfront_hosted_zone_id" {
+  description = "CloudFront hosted zone ID (for Route 53 alias records)"
+  value       = aws_cloudfront_distribution.main.hosted_zone_id
+}
+
+output "cf_logs_bucket" {
+  description = "S3 bucket storing CloudFront access logs"
+  value       = aws_s3_bucket.cf_logs.bucket
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -138,3 +138,62 @@ variable "log_group_name" {
   type        = string
   default     = "/stellar-spend/production"
 }
+
+# ── CloudFront / CDN ──────────────────────────────────────────────────────────
+
+variable "cf_price_class" {
+  description = "CloudFront price class (PriceClass_100 = US/EU, PriceClass_200 = + Asia, PriceClass_All = global)"
+  type        = string
+  default     = "PriceClass_100"
+  validation {
+    condition     = contains(["PriceClass_100", "PriceClass_200", "PriceClass_All"], var.cf_price_class)
+    error_message = "cf_price_class must be PriceClass_100, PriceClass_200, or PriceClass_All."
+  }
+}
+
+variable "cf_domain_aliases" {
+  description = "Custom domain aliases for the CloudFront distribution (e.g. [\"cdn.example.com\"]). Leave empty to use the default *.cloudfront.net domain."
+  type        = list(string)
+  default     = []
+}
+
+variable "cf_acm_certificate_arn" {
+  description = "ACM certificate ARN (must be in us-east-1) for custom domain aliases. Required when cf_domain_aliases is non-empty."
+  type        = string
+  default     = ""
+}
+
+variable "cf_origin_secret" {
+  description = "Shared secret sent as X-CloudFront-Secret header to the ALB origin to restrict direct access."
+  type        = string
+  sensitive   = true
+  default     = "change-me-in-production"
+}
+
+variable "cf_geo_restriction_type" {
+  description = "Geo-restriction type: 'whitelist' or 'blacklist'. Only used when cf_geo_restriction_locations is non-empty."
+  type        = string
+  default     = "blacklist"
+  validation {
+    condition     = contains(["whitelist", "blacklist"], var.cf_geo_restriction_type)
+    error_message = "cf_geo_restriction_type must be 'whitelist' or 'blacklist'."
+  }
+}
+
+variable "cf_geo_restriction_locations" {
+  description = "ISO 3166-1 alpha-2 country codes to whitelist or blacklist. Empty list disables geo-restrictions."
+  type        = list(string)
+  default     = []
+}
+
+variable "cf_invalidation_trigger" {
+  description = "Bump this value (e.g. a timestamp or deploy ID) to trigger a CloudFront cache invalidation on the next terraform apply."
+  type        = string
+  default     = "initial"
+}
+
+variable "alarm_sns_arn" {
+  description = "SNS topic ARN to receive CloudFront alarm notifications. Leave empty to disable."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
- Add terraform/cloudfront.tf with CloudFront distribution (ALB origin)
- Configure three cache policies: static assets (1yr), pages (1hr), no-cache (API)
- Add origin request policy forwarding required headers to ALB
- Implement CloudFront Function for security headers (HSTS, X-Frame-Options, etc.)
- Configure SSL/TLS with TLSv1.2_2021 minimum and redirect-to-https
- Add geo-restriction support (whitelist/blacklist via variables)
- Add cache invalidation via null_resource on deploy
- Add CloudWatch alarms for 5xx rate, 4xx rate, and origin latency
- Add S3 bucket for CloudFront access logs with lifecycle policy
- Append CDN variables to variables.tf (price class, aliases, ACM cert, geo, etc.)
- Append CDN outputs to outputs.tf (distribution ID, domain, hosted zone)
- Update terraform/envs/staging.tfvars with CDN defaults
- Add docs/cdn.md with full setup, security, and monitoring documentation

Closes #516
Configure RDS automated backups
Implement point-in-time recovery
Add backup verification
Create backup restoration testing
Implement backup retention policies
Add backup monitoring
Create backup documentation
Test disaster recovery procedures
Closes #512

Configure AWS Secrets Manager
Implement secret rotation
Add secret access auditing
Create secret versioning
Implement secret encryption
Add secret injection in deployments
Create secret management documentation
Test secret rotation procedures
Closes #514 
Closes #509 
Add CloudWatch alarms
Create VPC and networking
Implement security groups
Add backup configuration
Document Terraform usage